### PR TITLE
Fix cutedsl bwd compile crash with quack-kernels 0.4.x

### DIFF
--- a/src/ffpa_attn/cutedsl/_ffpa_dkdv_d512_sm90.py
+++ b/src/ffpa_attn/cutedsl/_ffpa_dkdv_d512_sm90.py
@@ -936,7 +936,6 @@ class FFPAAttnBwdDKDVSm90SplitD:
       tiled_mma_SdP,
       sP,
       tidx,
-      self.arch,
       transpose=False,
       position_independent=True,
     )
@@ -946,7 +945,6 @@ class FFPAAttnBwdDKDVSm90SplitD:
       tiled_mma_SdP,
       sP_fp32,
       tidx,
-      self.arch,
       transpose=False,
       position_independent=False,
     )
@@ -1184,7 +1182,6 @@ class FFPAAttnBwdDKDVSm90SplitD:
       tiled_mma_SdP,
       sdS,
       tidx,
-      self.arch,
       transpose=False,
       position_independent=True,
     )
@@ -1449,7 +1446,6 @@ class FFPAAttnBwdDKDVSm90SplitD:
       tiled_mma_dV,
       sEpi,
       tidx,
-      self.arch,
       transpose=False,
       position_independent=True,
     )
@@ -1516,7 +1512,6 @@ class FFPAAttnBwdDKDVSm90SplitD:
       tiled_mma_dK,
       sEpi,
       tidx,
-      self.arch,
       transpose=False,
       position_independent=True,
     )

--- a/src/ffpa_attn/cutedsl/_ffpa_dq_d512_sm90.py
+++ b/src/ffpa_attn/cutedsl/_ffpa_dq_d512_sm90.py
@@ -994,7 +994,6 @@ class FFPAAttnBwdDQSm90SplitD:
       tiled_mma_SdP,
       sP_fp32,
       tidx,
-      self.arch,
       transpose=False,
       position_independent=False,
     )
@@ -1292,7 +1291,6 @@ class FFPAAttnBwdDQSm90SplitD:
       tiled_mma_SdP,
       sdS,
       tidx,
-      self.arch,
       transpose=False,
       position_independent=True,
     )
@@ -1652,7 +1650,6 @@ class FFPAAttnBwdDQSm90SplitD:
       tiled_mma_dQ,
       sEpi_half,
       tidx,
-      self.arch,
       transpose=False,
       position_independent=True,
     )


### PR DESCRIPTION
### Summary
Fix `TypeError: multiple values for argument 'transpose'` caused by `quack` 0.4.0 update.

### Changes
Removed the `self.arch` argument, which was previously passed as the 4th positional argument to `copy_utils.get_smem_store_C(...)`. This updates a total of 8 occurrences across the following files:
* `src/ffpa_attn/cutedsl/_ffpa_dkdv_d512_sm90.py` (5 occurrences)
* `src/ffpa_attn/cutedsl/_ffpa_dq_d512_sm90.py` (3 occurrences)

<img width="881" height="200" alt="image" src="https://github.com/user-attachments/assets/601697f0-e797-4b73-8bfb-9a1c8ab107ca" />


### Motivation / Context
In `quack` version `0.4.0`, the `arch` parameter was removed from the `copy_utils.get_smem_store_C` function signature. Because of this removal, the 4th positional argument in the new signature shifted to `transpose`. 

Passing `self.arch` at the 4th position collided with the explicitly defined `transpose=False` keyword argument passed later in the same function call, leading to a `multiple values for argument 'transpose'` error. Removing the obsolete `self.arch` argument resolves this conflict.


Fixes #191 

<img width="655" height="247" alt="image" src="https://github.com/user-attachments/assets/73f7851b-2608-4e7d-9cab-731adfae05ae" />
