### PR TITLE
deps: lower torch floor to >=2.10.0 and apache-tvm-ffi to >=0.1.6,<0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,10 @@ dependencies = [
     "ninja",
     "numpy",
     "ray", # autotuning
-    "torch>=2.11.0",
+    "torch>=2.10.0",
     "quack-kernels>=0.4.1",
     "nvidia-cutlass-dsl>=4.5.1",
-    "apache-tvm-ffi>=0.1.11,<0.2",
+    "apache-tvm-ffi>=0.1.6,<0.2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
cutedsl stack imposes no >=2.11 torch constraint (nvidia-cutlass-dsl has no torch dep; quack-kernels/apache-tvm-ffi require unpinned torch). The 2.11 floor was a forward-looking pin tied to fp8-over-DLPack, already worked around via uint8 in cute_dsl_utils.to_cute_tensor. apache-tvm-ffi relaxed to match the validated stack (0.1.6) and quack-kernels' own >=0.1.6 requirement.