### PR TITLE
chore(deps): pin CUTLASS DSL 4.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ dependencies = [
     "ray", # autotuning
     "torch>=2.10.0",
     "quack-kernels==0.6.1",
-    "nvidia-cutlass-dsl>=4.6,<4.7",
-    "apache-tvm-ffi>=0.1.12,<0.2",
+    "nvidia-cutlass-dsl==4.6.0",
+    "apache-tvm-ffi>=0.1.11,<0.2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Pin nvidia-cutlass-dsl to 4.6.0 and lower the minimum apache-tvm-ffi version to 0.1.11. Apache TVM FFI 0.1.11 already includes the map_dataclass_to_tuple fix required by CUTLASS DSL 4.6.0.