### PR TITLE
build: drop universal wheel tag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal=1
-
 [metadata]
 license_files = LICENSE
 desciption_file = README.md


### PR DESCRIPTION
Remove the legacy universal=1 wheel configuration so pure Python releases use the accurate py3-none-any tag instead of py2.py3-none-any. Verified with uv build and twine check.