### PR TITLE
Fix 32-bit overflow in Triton backward tensor offsets

### DIFF
--- a/src/ffpa_attn/triton/_ffpa_bwd.py
+++ b/src/ffpa_attn/triton/_ffpa_bwd.py
@@ -259,7 +259,10 @@ def _ffpa_bwd_pre_impl(
   _ = autotune_seqlen_q_bucket
 
   start_m = tl.program_id(0)
-  off_hb = tl.program_id(1)
+  # Keep dense tensor base offsets in i64.  Runtime strides can each fit in
+  # i32 while ``batch * head * sequence * headdim`` exceeds 2**31 elements;
+  # leaving the program id in i32 then wraps the base pointer multiplication.
+  off_hb = tl.program_id(1).to(tl.int64)
   off_b = off_hb // nheads
   off_h = off_hb % nheads
   offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
@@ -654,7 +657,7 @@ def _ffpa_bwd_dkdv(
   BLOCK_N: tl.constexpr,
 ) -> None:
   pid = tl.program_id(0)
-  off_hb = tl.program_id(2)
+  off_hb = tl.program_id(2).to(tl.int64)
   off_b = off_hb // nheads
   off_h = off_hb % nheads
 
@@ -933,7 +936,7 @@ def _ffpa_bwd_dkdvdq(
   BLOCK_N: tl.constexpr,
 ) -> None:
   pid = tl.program_id(0)
-  off_hb = tl.program_id(2)
+  off_hb = tl.program_id(2).to(tl.int64)
   off_b = off_hb // nheads
   off_h = off_hb % nheads
 
@@ -1198,7 +1201,7 @@ def _ffpa_bwd_dq(
   BLOCK_N: tl.constexpr,
 ) -> None:
   pid = tl.program_id(0)
-  off_hb = tl.program_id(2)
+  off_hb = tl.program_id(2).to(tl.int64)
   off_b = off_hb // nheads
   off_h = off_hb % nheads
 
@@ -1773,7 +1776,7 @@ def _ffpa_bwd_decode_stage1_kernel(
   # but dQ is a sum over all K blocks, so stage1 writes PartialDQ and the reduce
   # kernel below performs the cross-K accumulation.
   start_n_block = tl.program_id(0)
-  off_hb = tl.program_id(1)
+  off_hb = tl.program_id(1).to(tl.int64)
   off_b = off_hb // nheads
   off_h = off_hb % nheads
 
@@ -2023,7 +2026,7 @@ def _ffpa_bwd_decode_dq_reduce_kernel(
 ) -> None:
   d_block = tl.program_id(0)
   q_block = tl.program_id(1)
-  off_hb = tl.program_id(2)
+  off_hb = tl.program_id(2).to(tl.int64)
   off_b = off_hb // nheads
   off_h = off_hb % nheads
 


### PR DESCRIPTION
## Summary

- promote flattened batch/head program ids to `tl.int64` in Triton backward kernels
- prevent base-pointer wraparound when a dense tensor exceeds `2^31` elements
- cover the main, split-launch, fused, and decode backward paths

## Minimal reproduction

Run on an A800 80GB with ffpa-attn 0.2.2, PyTorch 2.11.0, and Triton 3.6.0:

```python
import torch
from ffpa_attn import ffpa_attn_func

B, HQ, HKV = 24, 16, 2
NQ, NKV, D = 256, 12288, 512
q = torch.randn(B, HQ, NQ, D, device="cuda", dtype=torch.bfloat16, requires_grad=True)
k = torch.randn(B, HKV, NKV, D, device="cuda", dtype=torch.bfloat16, requires_grad=True)
v = torch.randn_like(k, requires_grad=True)
mask = torch.zeros(B, 1, NQ, NKV, device="cuda", dtype=torch.bfloat16)

out = ffpa_attn_func(
    q, k, v,
    attn_mask=mask,
    dropout_p=0.0,
    is_causal=False,
    enable_gqa=True,
    backend="triton",
)
out.mean().backward()
```

Forward succeeds, but backward raises `Triton Error [CUDA]: an illegal memory access was encountered`.

GQA backward expands K/V to the query-head layout. Here each expanded tensor contains `24 * 16 * 12288 * 512 = 2,415,919,104` elements, crossing `2^31`. The individual runtime strides still fit in i32, so multiplying the i32 program id by those strides wraps the base pointer.

## Verification

On the same A800:

- `B=16, NKV=12288`: still passes forward/backward
- `B=24, NKV=12288`: failed before, passes after the patch
- `B=24, NKV=24576`: failed before, passes after the patch; each expanded K/V tensor exceeds `2^32` elements

All patched runs produced finite outputs and Q/K/V gradients.