### PR TITLE
Fix causal cross-attention alignment in Triton backward

### DIFF
--- a/src/ffpa_attn/triton/_ffpa_bwd.py
+++ b/src/ffpa_attn/triton/_ffpa_bwd.py
@@ -678,7 +678,10 @@ def _ffpa_bwd_dkdv(
     offs_m = tl.arange(0, BLOCK_M)
     offs_d = tl.arange(0, BLOCK_HEADDIM)
     num_block_m = tl.cdiv(seqlen_q, BLOCK_M)
-    begin_m = 0 if not IS_CAUSAL else start_n // BLOCK_M * BLOCK_M
+    kv_offset = seqlen_k - seqlen_q
+    begin_m = 0 if not IS_CAUSAL else tl.maximum(
+      0, start_n - kv_offset
+    ) // BLOCK_M * BLOCK_M
 
     for start_m in range(begin_m, num_block_m * BLOCK_M, BLOCK_M):
       offs_qm = start_m + offs_m
@@ -717,7 +720,11 @@ def _ffpa_bwd_dkdv(
       if not EVEN_M:
         S = tl.where(m_mask[:, None], S, float("-inf"))
       if IS_CAUSAL:
-        S = tl.where(offs_qm[:, None] >= (offs_n[None, :]), S, float("-inf"))
+        S = tl.where(
+          offs_qm[:, None] + kv_offset >= offs_n[None, :],
+          S,
+          float("-inf"),
+        )
       S = S * softmax_scale
       if HAS_ATTN_BIAS:
         bias = tl.load(
@@ -958,7 +965,10 @@ def _ffpa_bwd_dkdvdq(
     offs_m = tl.arange(0, BLOCK_M)
     offs_d = tl.arange(0, BLOCK_HEADDIM)
     num_block_m = tl.cdiv(seqlen_q, BLOCK_M)
-    begin_m = 0 if not IS_CAUSAL else start_n // BLOCK_M * BLOCK_M
+    kv_offset = seqlen_k - seqlen_q
+    begin_m = 0 if not IS_CAUSAL else tl.maximum(
+      0, start_n - kv_offset
+    ) // BLOCK_M * BLOCK_M
 
     for start_m in range(begin_m, num_block_m * BLOCK_M, BLOCK_M):
       offs_qm = start_m + offs_m
@@ -999,7 +1009,11 @@ def _ffpa_bwd_dkdvdq(
       if not EVEN_M:
         S = tl.where(m_mask[:, None], S, float("-inf"))
       if IS_CAUSAL:
-        S = tl.where(offs_qm[:, None] >= (offs_n[None, :]), S, float("-inf"))
+        S = tl.where(
+          offs_qm[:, None] + kv_offset >= offs_n[None, :],
+          S,
+          float("-inf"),
+        )
       S = S * softmax_scale
       if HAS_ATTN_BIAS:
         bias = tl.load(
@@ -1220,7 +1234,11 @@ def _ffpa_bwd_dq(
     offs_d = tl.arange(0, BLOCK_HEADDIM)
 
     num_block_n = tl.cdiv(seqlen_k, BLOCK_N)
-    end_n_k = start_m + BLOCK_M if IS_CAUSAL else num_block_n * BLOCK_N
+    kv_offset = seqlen_k - seqlen_q
+    end_n_k = (
+      start_m + BLOCK_M + kv_offset
+      if IS_CAUSAL else num_block_n * BLOCK_N
+    )
 
     for start_n_k in range(0, end_n_k, BLOCK_N):
       offs_nk = start_n_k + offs_n
@@ -1256,7 +1274,9 @@ def _ffpa_bwd_dq(
         S_qk = tl.where(offs_nk[None, :] < seqlen_k, S_qk, float("-inf"))
       if IS_CAUSAL:
         S_qk = tl.where(
-          offs_m[:, None] >= (offs_nk[None, :]), S_qk, float("-inf")
+          offs_m[:, None] + kv_offset >= offs_nk[None, :],
+          S_qk,
+          float("-inf"),
         )
       S_qk = S_qk * softmax_scale
       if HAS_ATTN_BIAS:

--- a/tests/test_ffpa_bwd.py
+++ b/tests/test_ffpa_bwd.py
@@ -1179,6 +1179,41 @@ def test_ffpa_bwd_cross_attention(dtype, Nq, Nkv, D):
 
 
 @pytest.mark.parametrize("dtype", DTYPES, ids=["fp16", "bf16"])
+def test_ffpa_bwd_triton_causal_cross_gqa_matches_sdpa(dtype):
+  """Triton backward uses the same tail-aligned causal mask as forward."""
+  B, Hq, Hkv, Nq, Nkv, D = 1, 8, 2, 512, 1024, 320
+  torch.manual_seed(11)
+  q = torch.randn(B, Hq, Nq, D, dtype=dtype, device="cuda", requires_grad=True)
+  k = torch.randn(
+    B, Hkv, Nkv, D, dtype=dtype, device="cuda", requires_grad=True
+  )
+  v = torch.randn(
+    B, Hkv, Nkv, D, dtype=dtype, device="cuda", requires_grad=True
+  )
+  grad_out = torch.randn_like(q)
+  scale = 1.0 / math.sqrt(D)
+
+  out = ffpa_attn_func(
+    q,
+    k,
+    v,
+    is_causal=True,
+    scale=scale,
+    backward_backend="triton",
+    enable_gqa=True,
+  )
+  out.backward(grad_out)
+
+  dq_ref, dk_ref, dv_ref = _sdpa_ref_grads(
+    q, k, v, True, scale, grad_out=grad_out
+  )
+  tol = _tolerance(dtype)
+  torch.testing.assert_close(q.grad, dq_ref, **tol)
+  torch.testing.assert_close(k.grad, dk_ref, **tol)
+  torch.testing.assert_close(v.grad, dv_ref, **tol)
+
+
+@pytest.mark.parametrize("dtype", DTYPES, ids=["fp16", "bf16"])
 @pytest.mark.parametrize("Nq,Nkv,D", [(512, 4096, 320), (512, 8192, 512)])
 def test_ffpa_bwd_sdpa_backend_causal_cross_attention(dtype, Nq, Nkv, D):
   """The SDPA backward backend must preserve causal cross-attention gradients."""


### PR DESCRIPTION
## Summary

- align generic Triton backward causal masking with the forward kernel for `seqlen_q != seqlen_k`
- apply the bottom-right causal offset to dK/dV and dQ loop bounds and masks
- add a causal cross-attention GQA regression test against PyTorch math SDPA

## Problem

The forward path uses bottom-right causal alignment (`q + seqlen_k - seqlen_q >= k`), while the generic backward path used square self-attention alignment (`q >= k`). For causal cross-attention with `seqlen_q < seqlen_k`, the forward output was correct but backward gradients could be incorrect or NaN.

This problem can be triggered in DiffusionGemma, where ffpa is used the efficient attention kernel for Gemma 4 and the diffusion procedure requires cross-attention.

## Validation

Validated on NVIDIA A100-SXM4-80GB with PyTorch 2.9.1 and Triton 3.5.1:

- targeted fp16/bf16 regression: 2 passed
- independent comparison against PyTorch math SDPA: relative L2 errors approximately 4e-4 to 6.5e-4 for fp16 and 3.6e-3 to 5.2e-3 for bf16
- forward and dQ/dK/dV are finite and aligned with the reference