### PR TITLE
Add native GQA backward without KV-head expansion

### DIFF
--- a/src/ffpa_attn/triton/__init__.py
+++ b/src/ffpa_attn/triton/__init__.py
@@ -404,6 +404,10 @@ def _bwd_triton_torch_op(
   dq.zero_()  # atomic_add accumulates from the initial value; must be zero.
   dk = _triton_bwd_grad_tensor_like(k, grad_kv_storage_dtype)
   dv = _triton_bwd_grad_tensor_like(v, grad_kv_storage_dtype)
+  if k.size(1) < q.size(1):
+    # Native GQA accumulates query-head groups with atomic_add.
+    dk.zero_()
+    dv.zero_()
   if attn_bias is not None and return_attn_bias_grad:
     grad_dtype = _attn_bias_grad_dtype(attn_bias, q, k)
     grad_attn_bias = torch.empty_like(attn_bias, dtype=grad_dtype)

--- a/src/ffpa_attn/triton/_ffpa_bwd.py
+++ b/src/ffpa_attn/triton/_ffpa_bwd.py
@@ -678,7 +678,10 @@ def _ffpa_bwd_dkdv(
     offs_m = tl.arange(0, BLOCK_M)
     offs_d = tl.arange(0, BLOCK_HEADDIM)
     num_block_m = tl.cdiv(seqlen_q, BLOCK_M)
-    begin_m = 0 if not IS_CAUSAL else start_n // BLOCK_M * BLOCK_M
+    kv_offset = seqlen_k - seqlen_q
+    begin_m = 0 if not IS_CAUSAL else tl.maximum(
+      0, start_n - kv_offset
+    ) // BLOCK_M * BLOCK_M
 
     for start_m in range(begin_m, num_block_m * BLOCK_M, BLOCK_M):
       offs_qm = start_m + offs_m
@@ -717,7 +720,11 @@ def _ffpa_bwd_dkdv(
       if not EVEN_M:
         S = tl.where(m_mask[:, None], S, float("-inf"))
       if IS_CAUSAL:
-        S = tl.where(offs_qm[:, None] >= (offs_n[None, :]), S, float("-inf"))
+        S = tl.where(
+          offs_qm[:, None] + kv_offset >= offs_n[None, :],
+          S,
+          float("-inf"),
+        )
       S = S * softmax_scale
       if HAS_ATTN_BIAS:
         bias = tl.load(
@@ -958,7 +965,10 @@ def _ffpa_bwd_dkdvdq(
     offs_m = tl.arange(0, BLOCK_M)
     offs_d = tl.arange(0, BLOCK_HEADDIM)
     num_block_m = tl.cdiv(seqlen_q, BLOCK_M)
-    begin_m = 0 if not IS_CAUSAL else start_n // BLOCK_M * BLOCK_M
+    kv_offset = seqlen_k - seqlen_q
+    begin_m = 0 if not IS_CAUSAL else tl.maximum(
+      0, start_n - kv_offset
+    ) // BLOCK_M * BLOCK_M
 
     for start_m in range(begin_m, num_block_m * BLOCK_M, BLOCK_M):
       offs_qm = start_m + offs_m
@@ -999,7 +1009,11 @@ def _ffpa_bwd_dkdvdq(
       if not EVEN_M:
         S = tl.where(m_mask[:, None], S, float("-inf"))
       if IS_CAUSAL:
-        S = tl.where(offs_qm[:, None] >= (offs_n[None, :]), S, float("-inf"))
+        S = tl.where(
+          offs_qm[:, None] + kv_offset >= offs_n[None, :],
+          S,
+          float("-inf"),
+        )
       S = S * softmax_scale
       if HAS_ATTN_BIAS:
         bias = tl.load(
@@ -1220,7 +1234,11 @@ def _ffpa_bwd_dq(
     offs_d = tl.arange(0, BLOCK_HEADDIM)
 
     num_block_n = tl.cdiv(seqlen_k, BLOCK_N)
-    end_n_k = start_m + BLOCK_M if IS_CAUSAL else num_block_n * BLOCK_N
+    kv_offset = seqlen_k - seqlen_q
+    end_n_k = (
+      start_m + BLOCK_M + kv_offset
+      if IS_CAUSAL else num_block_n * BLOCK_N
+    )
 
     for start_n_k in range(0, end_n_k, BLOCK_N):
       offs_nk = start_n_k + offs_n
@@ -1256,7 +1274,9 @@ def _ffpa_bwd_dq(
         S_qk = tl.where(offs_nk[None, :] < seqlen_k, S_qk, float("-inf"))
       if IS_CAUSAL:
         S_qk = tl.where(
-          offs_m[:, None] >= (offs_nk[None, :]), S_qk, float("-inf")
+          offs_m[:, None] + kv_offset >= offs_nk[None, :],
+          S_qk,
+          float("-inf"),
         )
       S_qk = S_qk * softmax_scale
       if HAS_ATTN_BIAS:

--- a/src/ffpa_attn/triton/_ffpa_bwd.py
+++ b/src/ffpa_attn/triton/_ffpa_bwd.py
@@ -544,6 +544,7 @@ def _ffpa_bwd_kernel_impl(
   EVEN_N: tl.constexpr,
   BLOCK_M: tl.constexpr,
   BLOCK_N: tl.constexpr,
+  GROUP_SIZE: tl.constexpr,
   USE_DKDVDQ_FUSION: tl.constexpr,
 ) -> None:
   # Keys for autotune and heuristics lookups.
@@ -577,7 +578,7 @@ def _ffpa_bwd_kernel_impl(
       headdim, dropout_p, philox_offset, IS_CAUSAL, HAS_ATTN_BIAS, HAS_DROPOUT,
       PHILOX_SEED, BIAS_REQUIRES_GRAD, GRAD_BIAS_NEEDS_REDUCTION,
       GRAD_BIAS_REDUCES_M, GRAD_BIAS_STORE_PARTIAL, BLOCK_HEADDIM, DTYPE,
-      EVEN_M, EVEN_N, BLOCK_M, BLOCK_N
+      EVEN_M, EVEN_N, BLOCK_M, BLOCK_N, GROUP_SIZE
     )
     _ffpa_bwd_dq(
       Q, K, V, DO, DQ, LSE, D, AttnBias, softmax_scale, stride_qb, stride_qh,
@@ -586,7 +587,7 @@ def _ffpa_bwd_kernel_impl(
       stride_dqm, stride_bb, stride_bh, stride_bm, stride_bn, nheads, seqlen_q,
       seqlen_k, seqlen_q_rounded, headdim, dropout_p, philox_offset, IS_CAUSAL,
       HAS_ATTN_BIAS, HAS_DROPOUT, PHILOX_SEED, BLOCK_HEADDIM, DTYPE, EVEN_N,
-      BLOCK_M, BLOCK_N
+      BLOCK_M, BLOCK_N, GROUP_SIZE
     )
 
 
@@ -652,18 +653,20 @@ def _ffpa_bwd_dkdv(
   EVEN_N: tl.constexpr,
   BLOCK_M: tl.constexpr,
   BLOCK_N: tl.constexpr,
+  GROUP_SIZE: tl.constexpr,
 ) -> None:
   pid = tl.program_id(0)
   off_hb = tl.program_id(2)
   off_b = off_hb // nheads
   off_h = off_hb % nheads
+  off_hkv = off_h // GROUP_SIZE
 
   Q += off_b * stride_qb + off_h * stride_qh
-  K += off_b * stride_kb + off_h * stride_kh
-  V += off_b * stride_vb + off_h * stride_vh
+  K += off_b * stride_kb + off_hkv * stride_kh
+  V += off_b * stride_vb + off_hkv * stride_vh
   DO += off_b * stride_dob + off_h * stride_doh
-  DK += off_b * stride_dkb + off_h * stride_dkh
-  DV += off_b * stride_dvb + off_h * stride_dvh
+  DK += off_b * stride_dkb + off_hkv * stride_dkh
+  DV += off_b * stride_dvb + off_hkv * stride_dvh
   D += off_hb * seqlen_q_rounded
   LSE += off_hb * seqlen_q_rounded
   if HAS_ATTN_BIAS:
@@ -810,7 +813,14 @@ def _ffpa_bwd_dkdv(
         # wrapper controls DK/DV storage by allocating these buffers as bf16,
         # fp16, or fp32; this repeated global accumulation then round-trips in
         # that storage dtype without needing a Triton-side dtype branch.
-        if start_m == begin_m:
+        if GROUP_SIZE > 1:
+          dk_d = tl.trans(tl.dot(tl.trans(q), dS, out_dtype=tl.float32))
+          tl.atomic_add(dk_ptrs, dk_d, sem="relaxed", mask=grad_mask)
+          dv_d = tl.trans(
+            tl.dot(tl.trans(do), P_drop.to(DTYPE), out_dtype=tl.float32)
+          )
+          tl.atomic_add(dv_ptrs, dv_d, sem="relaxed", mask=grad_mask)
+        elif start_m == begin_m:
           dk_d = tl.trans(tl.dot(tl.trans(q), dS, out_dtype=tl.float32))
           tl.store(dk_ptrs, dk_d, mask=grad_mask, eviction_policy="evict_last")
           dv_d = tl.trans(
@@ -1210,15 +1220,17 @@ def _ffpa_bwd_dq(
   EVEN_N: tl.constexpr,
   BLOCK_M: tl.constexpr,
   BLOCK_N: tl.constexpr,
+  GROUP_SIZE: tl.constexpr,
 ) -> None:
   pid = tl.program_id(0)
   off_hb = tl.program_id(2)
   off_b = off_hb // nheads
   off_h = off_hb % nheads
+  off_hkv = off_h // GROUP_SIZE
 
   Q += off_b * stride_qb + off_h * stride_qh
-  K += off_b * stride_kb + off_h * stride_kh
-  V += off_b * stride_vb + off_h * stride_vh
+  K += off_b * stride_kb + off_hkv * stride_kh
+  V += off_b * stride_vb + off_hkv * stride_vh
   DO += off_b * stride_dob + off_h * stride_doh
   DQ += off_b * stride_dqb + off_h * stride_dqh
   D += off_hb * seqlen_q_rounded
@@ -1396,6 +1408,7 @@ def _ffpa_bwd_dkdv_kernel_impl(
   EVEN_N: tl.constexpr,
   BLOCK_M: tl.constexpr,
   BLOCK_N: tl.constexpr,
+  GROUP_SIZE: tl.constexpr,
 ) -> None:
   _ = autotune_seqlen_q_bucket
   _ = autotune_seqlen_k_bucket
@@ -1413,7 +1426,7 @@ def _ffpa_bwd_dkdv_kernel_impl(
     dropout_p, philox_offset, IS_CAUSAL, HAS_ATTN_BIAS, HAS_DROPOUT,
     PHILOX_SEED, BIAS_REQUIRES_GRAD, GRAD_BIAS_NEEDS_REDUCTION,
     GRAD_BIAS_REDUCES_M, GRAD_BIAS_STORE_PARTIAL, BLOCK_HEADDIM, DTYPE, EVEN_M,
-    EVEN_N, BLOCK_M, BLOCK_N
+    EVEN_N, BLOCK_M, BLOCK_N, GROUP_SIZE
   )
 
 
@@ -1470,6 +1483,7 @@ def _ffpa_bwd_dq_kernel_impl(
   EVEN_N: tl.constexpr,
   BLOCK_M: tl.constexpr,
   BLOCK_N: tl.constexpr,
+  GROUP_SIZE: tl.constexpr,
 ) -> None:
   _ = autotune_seqlen_q_bucket
   _ = autotune_seqlen_k_bucket
@@ -1484,7 +1498,7 @@ def _ffpa_bwd_dq_kernel_impl(
     stride_bb, stride_bh, stride_bm, stride_bn, nheads, seqlen_q, seqlen_k,
     seqlen_q_rounded, headdim, dropout_p, philox_offset, IS_CAUSAL,
     HAS_ATTN_BIAS, HAS_DROPOUT, PHILOX_SEED, BLOCK_HEADDIM, DTYPE, EVEN_N,
-    BLOCK_M, BLOCK_N
+    BLOCK_M, BLOCK_N, GROUP_SIZE
   )
 
 
@@ -1543,6 +1557,7 @@ def _get_bwd_autotune(
         "autotune_dtype_key",
         "autotune_bias_key",
         "autotune_dropout_key",
+        "GROUP_SIZE",
       ],
       reset_to_zero=reset_args,
       cache_results=True,
@@ -1572,6 +1587,7 @@ def _get_bwd_dkdv_autotune(
         "autotune_dtype_key",
         "autotune_bias_key",
         "autotune_dropout_key",
+        "GROUP_SIZE",
       ],
       reset_to_zero=reset_args,
       cache_results=True,
@@ -1596,6 +1612,7 @@ def _get_bwd_dq_autotune(headdim: int, autotune_mode: str):
         "autotune_dtype_key",
         "autotune_bias_key",
         "autotune_dropout_key",
+        "GROUP_SIZE",
       ],
       reset_to_zero=["DQ"],
       cache_results=True,
@@ -2106,17 +2123,19 @@ def _ffpa_attn_backward_triton_impl(
 
   * ``lse`` must already expose the padded last-dimension storage required by
     masked Triton loads
-  * any GQA/MQA expansion of ``k`` and ``v`` must already be done
-  * ``dq``, ``dk``, and ``dv`` must already be allocated with the expanded
-    head layout expected by the selected kernel
+  * generic GQA/MQA uses compact ``k`` and ``v``; decode and TMA use expanded
+    heads
+  * ``dq``, ``dk``, and ``dv`` must already be allocated with the head layout
+    expected by the selected kernel
 
   The function only computes delta, dispatches the chosen Triton backward
   kernel, and writes gradients into the provided output buffers.
 
   :param do: Upstream output gradient with layout ``[B, Nh, Nq, D]``.
   :param q: Query tensor saved from forward, layout ``[B, Nh, Nq, D]``.
-  :param k: Key tensor saved from forward, layout ``[B, Nh, Nk, D]``.
-  :param v: Value tensor saved from forward, layout ``[B, Nh, Nk, D]``.
+  :param k: Key tensor saved from forward, layout ``[B, Nh_kv, Nk, D]`` for
+      generic GQA or ``[B, Nh_q, Nk, D]`` for expanded paths.
+  :param v: Value tensor with the same head layout as ``k``.
   :param o: Forward output tensor, layout ``[B, Nh, Nq, D]``.
   :param lse: Forward softmax log-sum-exp tensor with visible layout
     ``[B, Nh, Nq]`` and storage rounded on the last dimension.
@@ -2139,6 +2158,7 @@ def _ffpa_attn_backward_triton_impl(
   batch, nheads, seqlen_q, headdim = q.shape
   _, _, seqlen_k, _ = k.shape
   original_nheads_kv = original_nheads_kv or nheads
+  group_size = nheads // k.size(1)
   softmax_scale = softmax_scale or (1.0 / math.sqrt(headdim))
   # ``split_launch`` only changes whether the generic main path invokes dKdV
   # and dQ as separate launches. The duplicated S/dP/dS recompute exists in
@@ -2147,7 +2167,7 @@ def _ffpa_attn_backward_triton_impl(
   split_launch = enable_split_launch and seqlen_q >= 8
   use_dkdvdq_fusion = (
     bool(int(os.environ.get("FFPA_TRITON_BWD_FUSE_DKDVDQ", "0")))
-    and seqlen_q >= 8 and not split_launch
+    and seqlen_q >= 8 and not split_launch and group_size == 1
   )
 
   if enable_tma and seqlen_q >= 8:
@@ -2595,6 +2615,7 @@ def _ffpa_attn_backward_triton_impl(
       GRAD_BIAS_REDUCES_M=grad_bias_reduces_m,
       GRAD_BIAS_STORE_PARTIAL=grad_bias_store_partial,
       DTYPE=DTYPE,
+      GROUP_SIZE=group_size,
     )
     dq_args = (
       q,
@@ -2645,6 +2666,7 @@ def _ffpa_attn_backward_triton_impl(
       HAS_DROPOUT=has_dropout,
       PHILOX_SEED=philox_seed,
       DTYPE=DTYPE,
+      GROUP_SIZE=group_size,
     )
 
     def dkdv_grid(meta: dict) -> tuple[int, ...]:
@@ -2763,6 +2785,7 @@ def _ffpa_attn_backward_triton_impl(
       GRAD_BIAS_REDUCES_M=grad_bias_reduces_m,
       GRAD_BIAS_STORE_PARTIAL=grad_bias_store_partial,
       DTYPE=DTYPE,
+      GROUP_SIZE=group_size,
       USE_DKDVDQ_FUSION=use_dkdvdq_fusion,
     )
   else:
@@ -2839,6 +2862,7 @@ def _ffpa_attn_backward_triton_impl(
       GRAD_BIAS_REDUCES_M=grad_bias_reduces_m,
       GRAD_BIAS_STORE_PARTIAL=grad_bias_store_partial,
       DTYPE=DTYPE,
+      GROUP_SIZE=group_size,
       USE_DKDVDQ_FUSION=use_dkdvdq_fusion,
     )
     _ffpa_bwd[grid](*main_args, **main_meta, **main_config)
@@ -2891,8 +2915,7 @@ def _ffpa_attn_backward_triton(
   dispatch layer:
 
   * pad ``lse`` to the rounded sequence length required by the Triton kernels
-  * expand ``k`` / ``v`` for GQA or MQA when ``Nh_q > Nh_kv``
-  * allocate the expanded ``dq`` / ``dk`` / ``dv`` buffers
+  * prepare ``k`` / ``v`` for the selected GQA/MQA path
   * call :func:`_ffpa_attn_backward_triton_impl`
   * reduce expanded ``dk`` / ``dv`` back to the original KV head layout
   * cast the returned gradients back to the original input dtypes
@@ -2953,10 +2976,8 @@ def _ffpa_attn_backward_triton(
 
   original_nheads_kv = k.size(1)
   group_size = q.size(1) // original_nheads_kv
-  if group_size > 1:
-    # GQA/MQA contract: kernels operate on expanded query-head layout. Gradients
-    # for repeated KV heads are summed back into the original KV head dimension
-    # after the Triton op returns.
+  native_gqa = group_size > 1 and seqlen_q >= 8 and not enable_tma
+  if group_size > 1 and not native_gqa:
     k_in = k.repeat_interleave(group_size, dim=1).contiguous()
     v_in = v.repeat_interleave(group_size, dim=1).contiguous()
   else:
@@ -2976,8 +2997,10 @@ def _ffpa_attn_backward_triton(
     int(autotune_mode == "max"),
     int(preprocess_d_chunk),
     int(return_attn_bias_grad and attn_bias is not None),
-    2 if grad_kv_storage_dtype == torch.float16 else
-    int(grad_kv_storage_dtype == torch.float32),
+    1 if native_gqa else (
+      2 if grad_kv_storage_dtype == torch.float16 else
+      int(grad_kv_storage_dtype == torch.float32)
+    ),
     2 if grad_q_storage_dtype == torch.float16 else
     int(grad_q_storage_dtype == torch.float32),
     original_nheads_kv,
@@ -2990,7 +3013,7 @@ def _ffpa_attn_backward_triton(
     int(enable_split_launch),
   )
 
-  if group_size > 1:
+  if group_size > 1 and not native_gqa:
     dk = dk_expanded.reshape(
       k.size(0),
       k.size(1),

--- a/tests/test_ffpa_bwd.py
+++ b/tests/test_ffpa_bwd.py
@@ -1039,6 +1039,32 @@ def test_ffpa_bwd_gqa(dtype, Nh_q, Nh_kv, N, D):
   torch.testing.assert_close(v.grad, dv_ref, **tol)
 
 
+def test_ffpa_bwd_native_gqa_does_not_repeat_kv_heads(monkeypatch):
+  """Main Triton backward consumes compact GQA K/V tensors directly."""
+  B, Hq, Hkv, N, D = 1, 8, 2, 512, 320
+  dtype = torch.bfloat16
+  torch.manual_seed(19)
+  q = torch.randn(B, Hq, N, D, dtype=dtype, device="cuda", requires_grad=True)
+  k = torch.randn(B, Hkv, N, D, dtype=dtype, device="cuda", requires_grad=True)
+  v = torch.randn(B, Hkv, N, D, dtype=dtype, device="cuda", requires_grad=True)
+  grad_out = torch.randn_like(q)
+  scale = 1.0 / math.sqrt(D)
+  out = ffpa_attn_func(q, k, v, scale=scale, enable_gqa=True)
+  dq_ref, dk_ref, dv_ref = _sdpa_ref_grads(
+    q, k, v, False, scale, grad_out=grad_out
+  )
+
+  def fail_repeat_interleave(*args, **kwargs):
+    raise AssertionError("native GQA backward must not expand K/V heads")
+
+  monkeypatch.setattr(torch.Tensor, "repeat_interleave", fail_repeat_interleave)
+  out.backward(grad_out)
+  tol = _tolerance(dtype)
+  torch.testing.assert_close(q.grad, dq_ref, **tol)
+  torch.testing.assert_close(k.grad, dk_ref, **tol)
+  torch.testing.assert_close(v.grad, dv_ref, **tol)
+
+
 @pytest.mark.parametrize("dtype", DTYPES, ids=["fp16", "bf16"])
 @pytest.mark.parametrize(
   "Nh_q,Nh_kv,N,D", [(32, 4, 8192, 320), (8, 1, 8192, 320)]

--- a/tests/test_ffpa_bwd.py
+++ b/tests/test_ffpa_bwd.py
@@ -1179,6 +1179,41 @@ def test_ffpa_bwd_cross_attention(dtype, Nq, Nkv, D):
 
 
 @pytest.mark.parametrize("dtype", DTYPES, ids=["fp16", "bf16"])
+def test_ffpa_bwd_triton_causal_cross_gqa_matches_sdpa(dtype):
+  """Triton backward uses the same tail-aligned causal mask as forward."""
+  B, Hq, Hkv, Nq, Nkv, D = 1, 8, 2, 512, 1024, 320
+  torch.manual_seed(11)
+  q = torch.randn(B, Hq, Nq, D, dtype=dtype, device="cuda", requires_grad=True)
+  k = torch.randn(
+    B, Hkv, Nkv, D, dtype=dtype, device="cuda", requires_grad=True
+  )
+  v = torch.randn(
+    B, Hkv, Nkv, D, dtype=dtype, device="cuda", requires_grad=True
+  )
+  grad_out = torch.randn_like(q)
+  scale = 1.0 / math.sqrt(D)
+
+  out = ffpa_attn_func(
+    q,
+    k,
+    v,
+    is_causal=True,
+    scale=scale,
+    backward_backend="triton",
+    enable_gqa=True,
+  )
+  out.backward(grad_out)
+
+  dq_ref, dk_ref, dv_ref = _sdpa_ref_grads(
+    q, k, v, True, scale, grad_out=grad_out
+  )
+  tol = _tolerance(dtype)
+  torch.testing.assert_close(q.grad, dq_ref, **tol)
+  torch.testing.assert_close(k.grad, dk_ref, **tol)
+  torch.testing.assert_close(v.grad, dv_ref, **tol)
+
+
+@pytest.mark.parametrize("dtype", DTYPES, ids=["fp16", "bf16"])
 @pytest.mark.parametrize("Nq,Nkv,D", [(512, 4096, 320), (512, 8192, 512)])
 def test_ffpa_bwd_sdpa_backend_causal_cross_attention(dtype, Nq, Nkv, D):
   """The SDPA backward backend must preserve causal cross-attention gradients."""


### PR DESCRIPTION
## Summary

- keep K/V in their compact KV-head layout for the generic Triton GQA/MQA backward path
- map each query head to its KV head directly in dQ, dK, and dV
- accumulate compact dK/dV in fp32 across query groups
- retain the existing expanded-head fallback for decode (`seqlen_q < 8`) and TMA paths
- add a regression test that makes backward fail if it calls `repeat_interleave`

## Motivation

The current GQA backward repeats K/V and allocates dK/dV at the query-head count, then reduces the gradients back to the original KV heads. For 8x GQA this creates an 8x internal KV footprint and can consume tens of GiB for long contexts.

## Validation

NVIDIA A100-SXM4-80GB, PyTorch 2.9.1, Triton 3.5.1:

- complete backward suite: 150 passed, 8 skipped
- fp16 and bf16 comparisons against PyTorch math SDPA across GQA, MQA, cross-attention, causal, additive-mask, and irregular shapes
- dedicated no-expansion regression passes
- all production-shape dQ/dK/dV gradients are finite

For `B=24, Hq=16, Hkv=2, Nq=256, Nkv=12288, D=512, bf16`:

| | Existing expansion | Native GQA |
|---|---:|---:|
| Backward peak increment | 20.34 GiB | 3.47 GiB |
| Total peak | 21.75 GiB | 4.88 GiB |

This saves 16.88 GiB, or about 83% of the backward-specific peak allocation for this shape.

## Notes

This PR is stacked on #300 because the causal cross-attention GQA tests require that correctness fix. Once #300 merges, the remaining diff is the native GQA implementation. It is independent of the int64 offset fix in #299.

The fp32 atomic reduction introduces very small run-to-run differences in dK/dV (roughly 1e-6 relative L2 for fp16 and below 1e-5 for bf16 in repeated tests).