### PR TITLE
fix(ci): ensure fork PRs properly trigger and run CI

### DIFF
--- a/.github/workflows/check-mkdocs.yml
+++ b/.github/workflows/check-mkdocs.yml
@@ -12,7 +12,9 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
+      - '.github/**'
       - '.gitignore'
       - '.gitattributes'
       - 'LICENSE'
@@ -20,7 +22,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,13 +3,14 @@ name: pre-commit
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/src/ffpa_attn/triton/_ffpa_bwd.py
+++ b/src/ffpa_attn/triton/_ffpa_bwd.py
@@ -1251,8 +1251,7 @@ def _ffpa_bwd_dq(
     num_block_n = tl.cdiv(seqlen_k, BLOCK_N)
     kv_offset = seqlen_k - seqlen_q
     end_n_k = (
-      start_m + BLOCK_M + kv_offset
-      if IS_CAUSAL else num_block_n * BLOCK_N
+      start_m + BLOCK_M + kv_offset if IS_CAUSAL else num_block_n * BLOCK_N
     )
 
     for start_n_k in range(0, end_n_k, BLOCK_N):


### PR DESCRIPTION
- Explicitly set pull_request types to cover all trigger scenarios (opened, synchronize, reopened, ready_for_review)
- Align paths-ignore between push and pull_request in check-mkdocs.yml
- Fix concurrency: only cancel-in-progress for pull_request events, not for push to main (which was prematurely canceling main branch runs)
- Remove leftover artifacts from the pull_request_target misadventure

Root cause history: Copilot previously tried to fix fork PR CI failures by adding pull_request_target triggers, which caused GitHub to refuse checkout of fork PR code ("pwn request" protection). The correct fix is plain pull_request trigger + proper fork approval settings.