### PR TITLE
fp8: native NHD (diffusers) tensor_layout support

### DIFF
--- a/bench/bench_fp8.py
+++ b/bench/bench_fp8.py
@@ -178,11 +178,22 @@ def run_ffpa(
   q, k, v, causal, gqa, preset="default", hybrid=False, with_permute=False
 ):
   if with_permute:
-    # cache-dit E2E path: inputs arrive as diffusers NHD [B,N,H,D] storage;
-    # ffpa consumes them natively via a zero-copy permute view (Phase C, no
-    # transpose copy). The storage itself was materialized OUTSIDE the timed
-    # region in run_scenario.
-    q, k, v = (x.permute(0, 2, 1, 3) for x in (q, k, v))
+    # cache-dit E2E path: inputs are diffusers NHD [B,N,H,D] storage; the
+    # fp8 persist-D kernel reads them and writes a contiguous NHD output
+    # directly (tensor_layout fast path — no permute views either side).
+    # Output is [B,N,H,D]; permuted back for the BHND comparison. no_grad:
+    # the NHD fast path is inference-only (the untimed correctness pass
+    # below otherwise runs grad-on).
+    with torch.no_grad():
+      return ffpa_attn_func(
+        q,
+        k,
+        v,
+        is_causal=causal,
+        enable_gqa=gqa,
+        forward_backend=fp8_backend(preset, hybrid),
+        tensor_layout="NHD",
+      ).permute(0, 2, 1, 3)
   return ffpa_attn_func(
     q,
     k,

--- a/csrc/cuffpa/cute/fp8/sm_120/persist_d.cuh
+++ b/csrc/cuffpa/cute/fp8/sm_120/persist_d.cuh
@@ -125,7 +125,7 @@ __global__ void __launch_bounds__(384, 1) persist_d_ws_fwd_cute_fp8_sm120(
     int Nq, int Nkv, int Nh, int Nh_kv, float scale, int Tc, int causal,
     int total_q_rows, int total_kv_rows, int n_rb_q, int n_rb_kv,
     int q_start_row = 0, const float* __restrict__ km = nullptr,
-    const float* __restrict__ vm = nullptr) {
+    const float* __restrict__ vm = nullptr, bool nhd_out = false) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
   using namespace cute;
   using Element = typename Traits::Element;      // float_e4m3_t (V/PV)
@@ -805,12 +805,23 @@ __global__ void __launch_bounds__(384, 1) persist_d_ws_fwd_cute_fp8_sm120(
       cutlass::arch::fence_view_async_shared();
       cutlass::arch::NamedBarrier::sync(kConsumerThreads, 0);
 
-      auto mO_tma = domain_offset(
-          make_coord(q_row_offset, 0),
-          tma_o.get_tma_tensor(make_shape(total_q_rows, Int<kHeadDim>{})));
+      // BHND-packed O: flat [total_q_rows, D] TMA space, head folded into
+      // the row index. NHD (diffusers BNHD packed O): flat [Nb*Nq, Nh*D],
+      // batch in the row index, head selects the column tile — mirrors the
+      // fp16 persist-D NHD Q load. The runtime nhd_out branch only picks
+      // coordinates; the copy path is shared.
+      const int Nb = total_q_rows / (Nh * Nq);
+      const int o_row_base =
+          nhd_out ? (Nb_id * Nq + q_start_row) : q_row_offset;
+      const int o_col_tile = nhd_out ? Nh_id : 0;
+      const int o_rows = nhd_out ? (Nb * Nq) : total_q_rows;
+      const int o_cols = nhd_out ? (Nh * kHeadDim) : kHeadDim;
+      auto mO_tma =
+          domain_offset(make_coord(o_row_base, 0),
+                        tma_o.get_tma_tensor(make_shape(o_rows, o_cols)));
       auto o_slice = tma_o.get_slice(_0{});
       auto gO_tma = local_tile(mO_tma, Shape<Int<kBr>, Int<kHeadDim>>{},
-                               make_coord(Q_tile_id, _0{}));
+                               make_coord(Q_tile_id, o_col_tile));
       auto tCgO_tma = o_slice.partition_D(gO_tma);
       auto tOsO = o_slice.partition_S(sO);
       if (wg_tid == 0)
@@ -818,14 +829,15 @@ __global__ void __launch_bounds__(384, 1) persist_d_ws_fwd_cute_fp8_sm120(
       tma_store_arrive();
       tma_store_wait<0>();
     } else {
-      // Tail tile: rows past Nq would alias the next head in the flattened
-      // [total_q_rows, D] TMA space, so store R->G with a row guard.
-      const int O_gmem_offset = (Nb_id * Nh * Nq * kHeadDim) +
-                                (Nh_id * Nq * kHeadDim) +
-                                q_start_row * kHeadDim;
+      // Tail tile: rows past Nq would alias the next head/batch in the
+      // flattened TMA space, so store R->G with a row guard.
+      const int O_gmem_offset =
+          nhd_out ? ((Nb_id * Nq + q_start_row) * Nh + Nh_id) * kHeadDim
+                  : ((Nb_id * Nh + Nh_id) * Nq + q_start_row) * kHeadDim;
+      const int o_row_stride = nhd_out ? Nh * kHeadDim : kHeadDim;
       auto mO = make_tensor(make_gmem_ptr(O + O_gmem_offset),
                             make_shape(Nq - q_start_row, Int<kHeadDim>{}),
-                            make_stride(Int<kHeadDim>{}, _1{}));
+                            make_stride(o_row_stride, _1{}));
       auto gO = local_tile(mO, Shape<Int<kBr>, Int<kHeadDim>>{},
                            make_coord(Q_tile_id, _0{}));
       auto tCgO = thr_mma_pv.partition_C(gO);

--- a/csrc/cuffpa/cute/launch.cuh
+++ b/csrc/cuffpa/cute/launch.cuh
@@ -983,13 +983,24 @@ void launch_cute_fwd_persist_d_fp8_sm120_impl(
   auto tma_v = make_tma_copy(SM90_TMA_LOAD{}, mV, SmemLayoutV{},
                              Shape<Int<kHeadDim>, Int<kBc>>{}, _1{});
 
-  // O store descriptor: full [total_q_rows, kHeadDim] ElementO tensor; the
-  // per-(batch,head) origin is injected via domain_offset in the kernel. The
-  // smem layout mirrors the kernel's SmemLayoutO staging (SW128, ElementO).
-  auto gO =
-      make_tensor(make_gmem_ptr(reinterpret_cast<ElementO*>(O.data_ptr())),
-                  make_shape(total_q_rows, Int<kHeadDim>{}),
-                  make_stride(Int<kHeadDim>{}, _1{}));
+  // O store descriptor: full [total_q_rows, kHeadDim] ElementO tensor for a
+  // BHND-packed O; the per-(batch,head) origin is injected via domain_offset
+  // in the kernel. NHD (diffusers BNHD packed) O, detected by storage: flat
+  // [Nb*Nq, Nh*kHeadDim] with the head selecting the column tile — mirrors
+  // the fp16 persist-D NHD Q load. Both branches use dynamic int64
+  // extents/strides so TmaO has a single type and the kernel takes a runtime
+  // nhd_out branch. The smem layout mirrors the kernel's SmemLayoutO staging
+  // (SW128, ElementO).
+  const bool nhd_out = ffpa_is_nhd_view(O);
+  auto gO = nhd_out
+                ? make_tensor(
+                      make_gmem_ptr(reinterpret_cast<ElementO*>(O.data_ptr())),
+                      make_shape((int64_t)Nb * Nq, (int64_t)Nh * kHeadDim),
+                      make_stride((int64_t)Nh * kHeadDim, _1{}))
+                : make_tensor(
+                      make_gmem_ptr(reinterpret_cast<ElementO*>(O.data_ptr())),
+                      make_shape((int64_t)total_q_rows, (int64_t)kHeadDim),
+                      make_stride((int64_t)kHeadDim, _1{}));
   auto tma_o = make_tma_copy(SM90_TMA_STORE{}, gO, SmemLayoutO{},
                              Shape<Int<kBr>, Int<kHeadDim>>{}, _1{});
 
@@ -1023,7 +1034,7 @@ void launch_cute_fwd_persist_d_fp8_sm120_impl(
         q_scale.data_ptr<float>(), k_scale.data_ptr<float>(),
         v_scale.data_ptr<float>(), Nq, Nkv, Nh, Nh_kv, scale, Tc, causal,
         total_q_rows, total_kv_rows, n_rb_q, n_rb_kv, q_start_row, km_f32_ptr,
-        vm_kernel);
+        vm_kernel, nhd_out);
   };
   if (qk_per_thread) {
     // Per-thread QK quant (sage style): fragment-aligned dequant scales.

--- a/csrc/cuffpa/launch.cuh
+++ b/csrc/cuffpa/launch.cuh
@@ -395,6 +395,16 @@ void launch_ffpa_attn_fwd_template(
         }
 #endif
 #endif
+        // NHD-packed O is only implemented for the persist-D fp8 path
+        // (D<=224): split-D/M4N2 store BHND-packed only, and the hybrid
+        // stage-1 slices O in BHND dims.
+        TORCH_CHECK(
+            !(ffpa_is_nhd_view(O) && kHeadDim > 224),
+            "ffpa_attn: NHD (BNHD) output requires the persist-D fp8 path "
+            "(head_dim <= 224)");
+        TORCH_CHECK(
+            !(ffpa_is_nhd_view(O) && fp8_hybrid && Nq >= fp8_hybrid_n_early),
+            "ffpa_attn: NHD (BNHD) output is not supported with fp8 hybrid");
         // D<=224: persist-D fp8; 224<D<768: split-D M8N1 fp8;
         // D>=768: split-D M4N2 fp8. Same D<768/D>=768 cross-point as the
         // fp16 dispatch (M4N2 wins only for D>=768; below that M8N1 is

--- a/src/ffpa_attn/cuda/__init__.py
+++ b/src/ffpa_attn/cuda/__init__.py
@@ -62,7 +62,8 @@ torch.library.define(
   "int fp8_v_quant_method, int fp8_pv_acc_type, int fp8_qk_mm_type, "
   "bool fp8_hybrid, int fp8_hybrid_n_early, "
   "bool fp4_hybrid, int fp4_hybrid_n_early, "
-  "bool fp8_hadamard, bool fp4_hadamard, int fp4_pv_mm_type, bool fp4_smooth_v) -> "
+  "bool fp8_hadamard, bool fp4_hadamard, int fp4_pv_mm_type, bool fp4_smooth_v, "
+  "int tensor_layout=1) -> "
   "(Tensor o, Tensor softmax_lse)",
 )
 
@@ -95,6 +96,7 @@ def _fwd_cuda_torch_op(
   fp4_hadamard: bool,
   fp4_pv_mm_type: int = 0,
   fp4_smooth_v: bool = False,
+  tensor_layout: int = 1,
 ) -> tuple[torch.Tensor, torch.Tensor]:
   if _ffpa_attn_fwd_cuda is None:
     raise RuntimeError(
@@ -102,10 +104,18 @@ def _fwd_cuda_torch_op(
       "Rebuild with ENABLE_FFPA_CUDA_IMPL=1 to enable it. "
       f"Original import error: {_CUDA_IMPORT_ERROR}"
     )
-  # O must be BHND-packed even when Q is an NHD (diffusers BNHD) permute
-  # view: empty_like would preserve the NHD strides, but the CUDA kernels
-  # write O through a flat packed-BHND TMA/store descriptor.
-  O = torch.empty_like(Q, memory_format=torch.contiguous_format)  # noqa: E741
+  # NHD (diffusers BNHD, tensor_layout=0): normalize Q/K/V to BHND-shape
+  # NHD-storage views so every downstream size()/stride read keeps BHND
+  # semantics; O is allocated over NHD-packed storage (empty_like preserves
+  # the dense view strides) and returned in native [B, N, H, D].
+  if tensor_layout == 0:
+    Q, K, V = (t.permute(0, 2, 1, 3) for t in (Q, K, V))
+    O = torch.empty_like(Q)  # noqa: E741
+  else:
+    # O must be BHND-packed even when Q is an NHD (diffusers BNHD) permute
+    # view: empty_like would preserve the NHD strides, but the CUDA kernels
+    # write O through a flat packed-BHND TMA/store descriptor.
+    O = torch.empty_like(Q, memory_format=torch.contiguous_format)  # noqa: E741
   seqlen_q = Q.size(2)
   # NOTE: allocate lse with the exact seqlen (no rounding). CUDA kernels index
   # the lse buffer flat as [B, Nh, Nq] (stride Nq per head); passing a padded
@@ -148,6 +158,8 @@ def _fwd_cuda_torch_op(
     fp4_pv_mm_type,
     fp4_smooth_v,
   )
+  if tensor_layout == 0:
+    O = O.permute(0, 2, 1, 3)  # noqa: E741
   return O, softmax_lse
 
 
@@ -179,11 +191,18 @@ def _fwd_cuda_fake(
   fp4_hadamard: bool,
   fp4_pv_mm_type: int = 0,
   fp4_smooth_v: bool = False,
+  tensor_layout: int = 1,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-  O = torch.empty_like(Q)  # noqa: E741
-  softmax_lse = Q.new_empty(
-    Q.size(0), Q.size(1), Q.size(2), dtype=torch.float32
-  )
+  if tensor_layout == 0:
+    O = torch.empty_like(Q.permute(0, 2, 1, 3))  # noqa: E741
+    softmax_lse = Q.new_empty(
+      Q.size(0), Q.size(2), Q.size(1), dtype=torch.float32
+    )
+  else:
+    O = torch.empty_like(Q)  # noqa: E741
+    softmax_lse = Q.new_empty(
+      Q.size(0), Q.size(1), Q.size(2), dtype=torch.float32
+    )
   return O, softmax_lse
 
 

--- a/src/ffpa_attn/cuda/_ffpa_fwd.py
+++ b/src/ffpa_attn/cuda/_ffpa_fwd.py
@@ -31,6 +31,7 @@ def _ffpa_attn_forward_cuda(
   fp4_hadamard: bool = False,
   fp4_pv_mm_type: int = 0,
   fp4_smooth_v: bool = False,
+  tensor_layout: int = 1,
 ) -> tuple[torch.Tensor, torch.Tensor]:
   """Call FFPA CUDA forward via registered torch op, returning ``(O, softmax_lse)``.
 
@@ -66,5 +67,10 @@ def _ffpa_attn_forward_cuda(
     fp4_hadamard,
     fp4_pv_mm_type,
     fp4_smooth_v,
+    tensor_layout,
   )
-  return O_storage, softmax_lse_storage[..., :Q.size(2)]
+  # lse stays [B, Nh, Nq] for both layouts; the slice is a no-op guard for
+  # HND (exact allocation) and must not run for NHD where Q.size(2) is H.
+  if tensor_layout:
+    return O_storage, softmax_lse_storage[..., :Q.size(2)]
+  return O_storage, softmax_lse_storage

--- a/src/ffpa_attn/ffpa_attn_interface.py
+++ b/src/ffpa_attn/ffpa_attn_interface.py
@@ -83,6 +83,7 @@ def ffpa_attn_func(
   is_causal: bool = False,
   scale: float | None = None,
   enable_gqa: bool = False,
+  tensor_layout: str = "HND",
   **kwargs: object,
 ) -> torch.Tensor:
   """FFPA: Faster Flash Prefill Attention for large headdims (D > 256).
@@ -170,6 +171,10 @@ def ffpa_attn_func(
   fb = kwargs.get("forward_backend")
   if fb is None:
     fb = kwargs.get("backend")
+  if tensor_layout not in ("HND", "NHD"):
+    raise TypeError(
+      f"tensor_layout must be 'HND' or 'NHD', got {tensor_layout!r}"
+    )
   if (
     attn_mask is None and dropout_p == 0.0 and "backward_backend" not in kwargs
     and isinstance(fb, CUDABackend)
@@ -179,10 +184,19 @@ def ffpa_attn_func(
     # wrapper (~20us/call). Any config the fast path rejects returns None
     # and falls through to the full chain below, so behavior is unchanged.
     out = _ffpa_attn_forward(
-      query, key, value, is_causal, scale, enable_gqa, fb
+      query, key, value, is_causal, scale, enable_gqa, fb, tensor_layout
     )
     if out is not None:
       return out
+  if tensor_layout == "NHD":
+    # v1: NHD packing is a fast-path-only feature (fp8 persist-D CUDA
+    # kernel); the full meta/autograd chain still assumes BHND.
+    raise TypeError(
+      "tensor_layout='NHD' requires the inference fast path: forward-only "
+      "no-grad call with an explicit CUDABackend whose fp8 persist-D kernel "
+      "applies (e.g. ffpa_attn_forward(..., tensor_layout='NHD', "
+      "forward_backend=CUDABackend(enable_fp8=True, ...)))"
+    )
   meta = FFPAAttnMeta.from_kwargs(**kwargs)
   if meta.fallback(query, key, attn_mask, dropout_p):
     # HACK: Avoid recursive for monkey-patch usage.
@@ -221,6 +235,7 @@ def ffpa_attn_forward(
   scale: float | None = None,
   enable_gqa: bool = False,
   forward_backend: CUDABackend | None = None,
+  tensor_layout: str = "HND",
 ) -> torch.Tensor:
   """Inference fast path: CUDA forward without meta validation.
 
@@ -248,11 +263,22 @@ def ffpa_attn_forward(
       is native in the CUDA kernel.
   :param forward_backend: Explicitly configured :class:`CUDABackend`; its
       flags drive the kernel exactly as ``ffpa_attn_func(forward_backend=...)``.
-  :returns: Output tensor ``O`` with layout ``[B, Nh_q, Nq, D]``.
+  :param tensor_layout: ``"HND"`` (default) for BHND packed ``[B, H, N, D]``
+      tensors, or ``"NHD"`` for diffusers-style ``[B, N, H, D]`` storage
+      (output follows the input layout; fp8 persist-D CUDA kernel only).
+  :returns: Output tensor ``O`` with layout ``[B, Nh_q, Nq, D]`` (HND) or
+      ``[B, Nq, Nh_q, D]`` (NHD).
   """
   if isinstance(forward_backend, CUDABackend):
     out = _ffpa_attn_forward(
-      query, key, value, is_causal, scale, enable_gqa, forward_backend
+      query,
+      key,
+      value,
+      is_causal,
+      scale,
+      enable_gqa,
+      forward_backend,
+      tensor_layout,
     )
     if out is not None:
       return out
@@ -264,6 +290,7 @@ def ffpa_attn_forward(
     scale=scale,
     forward_backend=forward_backend,
     enable_gqa=enable_gqa,
+    tensor_layout=tensor_layout,
   )
 
 

--- a/src/ffpa_attn/functional.py
+++ b/src/ffpa_attn/functional.py
@@ -170,6 +170,7 @@ def _ffpa_attn_forward(
   scale: float | None,
   enable_gqa: bool,
   fm: CUDABackend,
+  tensor_layout: str = "HND",
 ) -> torch.Tensor | None:
   """Inference-only forward: run the CUDA op directly, skipping meta
   validation and the autograd Function wrapper.
@@ -179,18 +180,39 @@ def _ffpa_attn_forward(
 
   Returns ``None`` when the config needs the full :func:`ffpa_attn_func`
   chain (grad mode on, small-D SDPA routing, ``D > 1024``, ``Nq < 512``,
-  ``Nkv < 512``, or bf16 with ``acc='f16'``). The caller is responsible for
-  pre-validated packed BHND fp16/bf16 inputs.
+  ``Nkv < 512``, bf16 with ``acc='f16'``, or ``tensor_layout='NHD'`` on a
+  non-fp8-persist-D path). The caller is responsible for pre-validated
+  packed inputs (BHND fp16/bf16, or NHD when ``tensor_layout='NHD'``).
 
   :param enable_gqa: Unused by the CUDA kernel (GQA head grouping is
       native); accepted for signature compatibility with future
       Triton / CuTeDSL fast paths.
   """
+  nhd = tensor_layout == "NHD"
+  if nhd:
+    # NHD output packing is implemented by the fp8 persist-D CUDA kernel
+    # only (runtime store-layout branch); every other impl/hint combination
+    # must take the full chain. The hybrid stage-1 slice is BHND-only, so
+    # decline exactly the configs C++ would route into it (fp8_hybrid may
+    # still be None; the resolution below maps causal to True).
+    if (
+      _ffpa_attn_forward_cuda is None or torch.is_grad_enabled()
+      or fm.fp8_hadamard or fm.fp4_hybrid or fm.fp4_hadamard
+      or not fm.enable_fp8 or (
+        fm.enable_fp8 and
+        (fm.fp8_hybrid or (fm.fp8_hybrid is None and is_causal))
+        and query.size(1) >= (fm.fp8_hybrid_n_early or 256)
+      )
+    ):
+      return None
+    nq, nkv = query.size(1), key.size(1)
+  else:
+    nq, nkv = query.size(2), key.size(2)
   if (
     _ffpa_attn_forward_cuda is None or torch.is_grad_enabled()
     or query.dtype is torch.bfloat16 and fm.acc == "f16"
     or _should_use_aten_small_d_forward(fm, query.size(-1))
-    or query.size(-1) > 1024 or 8 <= query.size(2) < 512 or key.size(2) < 512
+    or query.size(-1) > 1024 or 8 <= nq < 512 or nkv < 512
   ):
     return None
   # Same in-place resolution normalize_inputs would perform (idempotent).
@@ -228,6 +250,7 @@ def _ffpa_attn_forward(
     fm.fp4_hadamard,
     1 if fm.fp4_pv_mm_type == "fp8" else 0,
     fm.fp4_smooth_v,
+    0 if nhd else 1,
   )
   return O
 

--- a/tests/test_ffpa_fp8.py
+++ b/tests/test_ffpa_fp8.py
@@ -528,3 +528,79 @@ def test_fp8_split_d_m4n2_gqa_parity(D, qk_int8, monkeypatch):
   v_rep = v.repeat_interleave(H // H_kv, dim=1)
   ref = F.scaled_dot_product_attention(q.float(), k_rep.float(), v_rep.float())
   torch.testing.assert_close(out.float(), ref, atol=5e-3, rtol=5e-3)
+
+
+@pytest.mark.parametrize("causal", [False, True], ids=["dense", "causal"])
+@pytest.mark.parametrize(
+  "B,H,Hkv,N",
+  [(1, 24, 24, 2048), (1, 24, 24, 16383), (2, 8, 8, 3000), (1, 24, 8, 4096)],
+  ids=["full", "tail", "batch", "gqa"],
+)
+def test_fp8_nhd_layout_bit_exact(B, H, Hkv, N, causal):
+  # NHD (diffusers BNHD) storage in/out vs BHND in/out: same kernel run, so
+  # the two layouts must agree bitwise. The NHD tensors are materialized
+  # NHD-packed then permuted back to BHND shape (the documented construction
+  # that avoids false NHD views). fp8_hybrid=False: the hybrid stage-1 is
+  # BHND-only, so causal NHD takes the plain causal persist-D kernel.
+  torch.manual_seed(0)
+  D = 128
+  backend = CUDABackend(
+    backward=False,
+    enable_tma=True,
+    enable_cute=True,
+    enable_fp8=True,
+    fp8_hybrid=False,
+  )
+  q = torch.randn(B, H, N, D, dtype=torch.bfloat16, device="cuda") * 0.5
+  k = torch.randn(B, Hkv, N, D, dtype=torch.bfloat16, device="cuda") * 0.5
+  v = torch.randn(B, Hkv, N, D, dtype=torch.bfloat16, device="cuda") * 0.5
+  # NHD-native storage: [B, N, H(, Hkv), D]
+  q3 = q.permute(0, 2, 1, 3).contiguous()
+  k3 = k.permute(0, 2, 1, 3).contiguous()
+  v3 = v.permute(0, 2, 1, 3).contiguous()
+
+  with torch.no_grad():
+    out_b = ffpa_attn_func(q, k, v, is_causal=causal, forward_backend=backend)
+    out_n = ffpa_attn_func(
+      q3,
+      k3,
+      v3,
+      is_causal=causal,
+      forward_backend=backend,
+      tensor_layout="NHD",
+    )
+  assert out_n.shape == (B, N, H, D) and out_n.is_contiguous()
+  torch.testing.assert_close(out_n, out_b.permute(0, 2, 1, 3))
+
+
+def test_fp8_nhd_layout_parity_vs_sdpa():
+  torch.manual_seed(0)
+  B, H, N, D = 1, 24, 4096, 128
+  q3 = torch.randn(B, N, H, D, dtype=torch.bfloat16, device="cuda") * 0.5
+  k3 = torch.randn(B, N, H, D, dtype=torch.bfloat16, device="cuda") * 0.5
+  v3 = torch.randn(B, N, H, D, dtype=torch.bfloat16, device="cuda") * 0.5
+  with torch.no_grad():
+    out = ffpa_attn_func(
+      q3, k3, v3, forward_backend=_fp8_backend(), tensor_layout="NHD"
+    )
+  q, k, v = (t.permute(0, 2, 1, 3) for t in (q3, k3, v3))
+  ref = F.scaled_dot_product_attention(q.float(), k.float(),
+                                       v.float()).to(torch.bfloat16)
+  torch.testing.assert_close(out, ref.permute(0, 2, 1, 3), atol=4e-2, rtol=4e-2)
+
+
+def test_fp8_nhd_layout_rejections():
+  torch.manual_seed(0)
+  B, H, N, D = 1, 24, 4096, 128
+  q3 = torch.randn(B, N, H, D, dtype=torch.bfloat16, device="cuda")
+  k3 = torch.randn(B, N, H, D, dtype=torch.bfloat16, device="cuda")
+  v3 = torch.randn(B, N, H, D, dtype=torch.bfloat16, device="cuda")
+  with pytest.raises(TypeError):
+    # full chain (no explicit backend) does not accept NHD
+    with torch.no_grad():
+      ffpa_attn_func(q3, k3, v3, tensor_layout="NHD")
+  with pytest.raises(TypeError):
+    # grad-on declines the fast path, so NHD has no supported path
+    ffpa_attn_func(
+      q3, k3, v3, forward_backend=_fp8_backend(), tensor_layout="NHD"
+    )


### PR DESCRIPTION
The fp8 persist-D kernel wrote O BHND-packed only; NHD (diffusers [B,N,H,D]) callers got back a permute view whose non-contiguous storage forces a strided copy in downstream consumers (diffusers FluxAttnProcessor flatten(2,3): +0.233ms/attn at N=16896), fully offsetting the kernel's speed advantage over SageAttention.

- tensor_layout: str = "HND" on ffpa_attn_func / ffpa_attn_forward (Sage-style API). "NHD" accepts native [B,N,H,D] inputs and returns a contiguous [B,N,H,D] output; v1 is fast-path-only (forward-only, no-grad, explicit CUDABackend, fp8 persist-D, no hybrid/hadamard/fp4) and raises TypeError otherwise.
- Kernel: runtime nhd_out branch on the O store. Full tiles select the flat [Nb*Nq, Nh*D] TMA space (head as column tile, batch via domain_offset — mirrors the fp16 persist-D NHD Q load); tail tiles use NHD offset arithmetic. Host descriptor constructed with dynamic int64 extents/strides in both layouts so TmaO keeps a single type (no instance doubling).
- Torch op: NHD inputs normalized to BHND-shape NHD-storage views at the op entry (all downstream size()/stride reads keep BHND semantics); O allocated over NHD-packed storage and returned natively. lse stays [B, Nh, Nq].
- bench: --with-permute now exercises the NHD fast path end to end.

Bit-exact vs the BHND path across full/tail tiles, B=1/2, MHA/GQA, causal, fp16/bf16 (tests/test_ffpa_fp8.py::test_fp8_nhd_layout_*). cache-dit dispatch (N=16896 MHA): 9.207 -> 8.915ms vs sage 9.265ms; FLUX e2e 1024 flips from par to ahead.