### PR TITLE
ffpa: strided-NHD true zero-copy across fp8/fp4/fp16 persist-D

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,13 +232,13 @@ python3 -m cache_dit.generate flux --attn ffpa_fp4 --seed 42 --height 1024 --wid
 
 |SDPA (17.19s)|FFPA-FP8 (16.08s)|Sage-2 (FP8, 16.21s)|FFPA-FP4 (15.99s)|
 |:---:|:---:|:---:|:---:|
-|<img src="./docs/assets/flux.1024.seed42.native.png" width="180px">|<img src="./docs/assets/flux.1024.seed42.ffpa_fp8.png" width="180px">|<img src="./docs/assets/flux.1024.seed42.sage.png" width="180px">|<img src="./docs/assets/flux.1024.seed42.ffpa_fp4.png" width="180px">|
+|<img src="./docs/assets/flux.1024.seed42.native.png" width="178px">|<img src="./docs/assets/flux.1024.seed42.ffpa_fp8.png" width="178px">|<img src="./docs/assets/flux.1024.seed42.sage.png" width="178px">|<img src="./docs/assets/flux.1024.seed42.ffpa_fp4.png" width="178px">|
 
 <i> FLUX.1-dev, seed=42, 28 steps, 2048 x 2048, NVIDIA RTX PRO 5000 </i>
 
 |SDPA (91.25s)|FFPA-FP8 (79.91s)|Sage-3 (FP4, 80.39s)|FFPA-FP4 (75.73s)|
 |:---:|:---:|:---:|:---:|
-|<img src="./docs/assets/flux.2048x2048.C0_native.png" width="180px">|<img src="./docs/assets/flux.2048x2048.C0_ffpa_fp8.png" width="180px">|<img src="./docs/assets/flux.2048x2048.C0_sage3.png" width="180px">|<img src="./docs/assets/flux.2048x2048.C0_ffpa_fp4.png" width="180px">|
+|<img src="./docs/assets/flux.2048x2048.C0_native.png" width="178px">|<img src="./docs/assets/flux.2048x2048.C0_ffpa_fp8.png" width="178px">|<img src="./docs/assets/flux.2048x2048.C0_sage3.png" width="178px">|<img src="./docs/assets/flux.2048x2048.C0_ffpa_fp4.png" width="178px">|
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -230,13 +230,13 @@ python3 -m cache_dit.generate flux --attn ffpa_fp4 --seed 42 --height 1024 --wid
 
 <i> FLUX.1-dev, seed=42, 28 steps, 1024 x 1024, NVIDIA RTX PRO 5000 </i>
 
-|SDPA-FA2 (17.2s)|FFPA-FP8 (16.2s)|SageAttn-2 (FP8, 16.2s)|FFPA-FP4 (16.1s)|
+|SDPA (17.19s)|FFPA-FP8 (16.08s)|Sage-2 (FP8, 16.21s)|FFPA-FP4 (15.99s)|
 |:---:|:---:|:---:|:---:|
 |<img src="./docs/assets/flux.1024.seed42.native.png" width="180px">|<img src="./docs/assets/flux.1024.seed42.ffpa_fp8.png" width="180px">|<img src="./docs/assets/flux.1024.seed42.sage.png" width="180px">|<img src="./docs/assets/flux.1024.seed42.ffpa_fp4.png" width="180px">|
 
 <i> FLUX.1-dev, seed=42, 28 steps, 2048 x 2048, NVIDIA RTX PRO 5000 </i>
 
-|SDPA-FA2 (92.3s)|FFPA-FP8 (80.0s)|SageAttn-3 (FP4, 80.4s)|FFPA-FP4 (76.1s)|
+|SDPA (91.25s)|FFPA-FP8 (79.91s)|Sage-3 (FP4, 80.39s)|FFPA-FP4 (75.73s)|
 |:---:|:---:|:---:|:---:|
 |<img src="./docs/assets/flux.2048x2048.C0_native.png" width="180px">|<img src="./docs/assets/flux.2048x2048.C0_ffpa_fp8.png" width="180px">|<img src="./docs/assets/flux.2048x2048.C0_sage3.png" width="180px">|<img src="./docs/assets/flux.2048x2048.C0_ffpa_fp4.png" width="180px">|
 

--- a/csrc/cuffpa/cute/fp8/quantize_fp8.cuh
+++ b/csrc/cuffpa/cute/fp8/quantize_fp8.cuh
@@ -331,7 +331,7 @@ __global__ void quantize_fp8_qkv_fused_kernel(
     QKOutT<kQKInt8>* __restrict__ K8, __nv_fp8_e4m3* __restrict__ VT8,
     float* __restrict__ q_scale, float* __restrict__ k_scale,
     float* __restrict__ v_scale, int N, int H, int ldy, int D_og,
-    Fp8InputLayout Lq, Fp8InputLayout Lkv,
+    Fp8InputLayout Lq, Fp8InputLayout Lkv, Fp8InputLayout Lv,
     const Element* __restrict__ km = nullptr,  // (B*H, kD) col means
     float inv_n = 0.0f) {
   constexpr int kVec = 8;
@@ -344,7 +344,7 @@ __global__ void quantize_fp8_qkv_fused_kernel(
   const int tid = threadIdx.x;
   const int warp = tid / 32;
   const int lane = tid % 32;
-  const Fp8InputLayout L = (role == 0) ? Lq : Lkv;
+  const Fp8InputLayout L = (role == 0) ? Lq : (role == 1) ? Lkv : Lv;
 
   constexpr int dv = kD / kVec;
   constexpr int total = kBlockRows * dv;
@@ -900,8 +900,11 @@ void launch_quantize_fp8_perthread_qk_sm120(
     void* k8, __nv_fp8_e4m3* vt8, float* q_scale, float* k_scale,
     float* v_scale, int B, int Nh, int Nh_kv, int Nq, int Nkv, int Nkv_pad,
     int D_og, Fp8InputLayout Lq, Fp8InputLayout Lkv, cudaStream_t stream,
-    const Element* km = nullptr, bool perm_vt = false, bool skip_vt = false) {
+    const Element* km = nullptr, bool perm_vt = false, bool skip_vt = false,
+    const Fp8InputLayout* Lv = nullptr) {
   using QKOut = QKOutT<kQKInt8>;
+  // V may carry its own (strided-NHD) layout; default mirrors K's.
+  const Fp8InputLayout Lv_ = Lv ? *Lv : Lkv;
   // Q: 128-row scale blocks, 64 scale per block; 2 threads/row (64-row
   // launch blocks) for DRAM latency hiding.
   {
@@ -926,7 +929,7 @@ void launch_quantize_fp8_perthread_qk_sm120(
       cudaFuncSetAttribute(vk, cudaFuncAttributeMaxDynamicSharedMemorySize,
                            kVtSmemBytes);
       vk<<<grid, 128, kVtSmemBytes, stream>>>(v_ptr, vt8, v_scale, Nkv, Nh_kv,
-                                              Nkv_pad, D_og, Lkv);
+                                              Nkv_pad, D_og, Lv_);
     };
     if (perm_vt)
       launch_vt(quantize_fp8_vt_kernel<Element, kBc, kHeadDim, true>);
@@ -955,8 +958,11 @@ void launch_quantize_fp8_sm120(const Element* q_ptr, const Element* k_ptr,
                                int Nh_kv, int Nq, int Nkv, int Nkv_pad,
                                int D_og, Fp8InputLayout Lq, Fp8InputLayout Lkv,
                                cudaStream_t stream, const Element* km = nullptr,
-                               bool perm_vt = false, bool skip_vt = false) {
+                               bool perm_vt = false, bool skip_vt = false,
+                               const Fp8InputLayout* Lv = nullptr) {
   using QKOut = QKOutT<kQKInt8>;
+  // V may carry its own (strided-NHD) layout; default mirrors K's.
+  const Fp8InputLayout Lv_ = Lv ? *Lv : Lkv;
   constexpr int kThreads = 128;
   // Dynamic smem for the VT staging tile (1B/elem); must match the kernels'
   // kPad. D is tiled into kDChunk-wide columns so the staging tile fits the
@@ -974,7 +980,7 @@ void launch_quantize_fp8_sm120(const Element* q_ptr, const Element* k_ptr,
         kernel<<<grid, kThreads, kVtSmemBytes, stream>>>(
             q_ptr, k_ptr, v_ptr, reinterpret_cast<QKOut*>(q8),
             reinterpret_cast<QKOut*>(k8), vt8, q_scale, k_scale, v_scale, Nq,
-            Nh, Nkv_pad, D_og, Lq, Lkv, km, 1.0f);
+            Nh, Nkv_pad, D_og, Lq, Lkv, Lv_, km, 1.0f);
       };
       if (perm_vt)
         launch_fused(quantize_fp8_qkv_fused_kernel<Element, kBr, kHeadDim,
@@ -1005,7 +1011,7 @@ void launch_quantize_fp8_sm120(const Element* q_ptr, const Element* k_ptr,
       cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
                            kVtSmemBytes);
       kernel<<<grid_kv, kThreads, kVtSmemBytes, stream>>>(
-          v_ptr, vt8, v_scale, Nkv, Nh_kv, Nkv_pad, D_og, Lkv);
+          v_ptr, vt8, v_scale, Nkv, Nh_kv, Nkv_pad, D_og, Lv_);
     };
     if (perm_vt)
       launch_vt(quantize_fp8_vt_kernel<Element, kBc, kHeadDim, true>);

--- a/csrc/cuffpa/cute/launch.cuh
+++ b/csrc/cuffpa/cute/launch.cuh
@@ -39,15 +39,59 @@ static inline bool ffpa_is_nhd_view(const torch::Tensor& X) {
          X.stride(1) == D && (B <= 1 || X.stride(0) == N * H * D);
 }
 
+// BHND-packed detection: contiguous [B, H, N, D] strides.
+static inline bool ffpa_is_bhnd_packed(const torch::Tensor& X) {
+  const long B = X.size(0), H = X.size(1), N = X.size(2), D = X.size(3);
+  return X.dim() == 4 && X.stride(3) == 1 && X.stride(2) == D &&
+         X.stride(1) == N * D && X.stride(0) == H * N * D;
+}
+
+// Strided-NHD predicate: an NHD-family [B, H, N, D] view whose row stride
+// exceeds H*D (fused-QKV interleaved chunk layouts) — neither BHND-packed
+// nor a packed-NHD permute view. stride(2) >= H*D excludes negative strides
+// and head-overlapping rows; stride(0) > 0 excludes reversed batches
+// (negative strides can still be %16-aligned).
+static inline bool ffpa_is_strided_nhd(const torch::Tensor& X) {
+  const long B = X.size(0), H = X.size(1), N = X.size(2), D = X.size(3);
+  return X.dim() == 4 && X.stride(3) == 1 && X.stride(1) == D &&
+         X.stride(2) >= H * D && !ffpa_is_nhd_view(X) &&
+         (B <= 1 || (X.stride(0) == X.stride(2) * N && X.stride(0) > 0));
+}
+
+// TMA consumers need 16B alignment on the base pointer and both row/batch
+// strides of a strided-NHD input.
+static inline void ffpa_check_strided_nhd_aligned(const torch::Tensor& X,
+                                                  const char* name) {
+  const long es = X.element_size();
+  TORCH_CHECK(reinterpret_cast<uintptr_t>(X.data_ptr()) % 16 == 0 &&
+                  (X.stride(2) * es) % 16 == 0 && (X.stride(0) * es) % 16 == 0,
+              "ffpa_attn: strided NHD ", name,
+              " requires a 16B-aligned data_ptr and 16B-aligned row/batch "
+              "strides (elemsize ",
+              es, ", strides ", X.stride(0), ",", X.stride(1), ",", X.stride(2),
+              ",1)");
+}
+
 // Fp8InputLayout from a [B, H, N, D] tensor's strides. Accepts BHND-packed
-// and NHD-view; anything else (arbitrary strides) is rejected.
-static inline ffpa_fp8::Fp8InputLayout ffpa_layout_of(const torch::Tensor& X,
-                                                      long N, long D) {
+// and NHD-view; anything else (arbitrary strides) is rejected unless
+// allow_strided_rows (persist-D opt-in): NHD-family views whose row stride
+// exceeds H*D (fused-QKV chunk layouts, e.g. FLUX.2 single-stream V) are
+// also accepted — the pre-kernels address rows through s_row, so any
+// 16B-aligned positive row/batch stride is legal. Split-D/M4N2 keep the
+// default strict gate.
+static inline ffpa_fp8::Fp8InputLayout ffpa_layout_of(
+    const torch::Tensor& X, long N, long D, bool allow_strided_rows = false) {
   const long B = X.size(0), H = X.size(1);
   TORCH_CHECK(X.dim() == 4 && X.stride(3) == 1,
               "ffpa_attn: Q/K/V must be 4-D with unit stride along D");
   if (ffpa_is_nhd_view(X))
     return {true, static_cast<int>(H), N * H * D, D, H * D};
+  if (allow_strided_rows && ffpa_is_strided_nhd(X)) {
+    ffpa_check_strided_nhd_aligned(X, "input");
+    const long s_row = X.stride(2);
+    const long s_batch = (B <= 1) ? N * s_row : X.stride(0);
+    return {true, static_cast<int>(H), s_batch, D, s_row};
+  }
   TORCH_CHECK(
       X.stride(2) == D && X.stride(1) == N * D && X.stride(0) == H * N * D,
       "ffpa_attn: Q/K/V must be BHND-contiguous or an NHD (BNHD) "
@@ -610,14 +654,30 @@ void launch_cute_fwd_persist_d_sm120(torch::Tensor Q, torch::Tensor K,
           : make_tensor(make_gmem_ptr(reinterpret_cast<Element*>(O.data_ptr())),
                         make_shape((int64_t)total_q_rows, (int64_t)kHeadDim),
                         make_stride((int64_t)kHeadDim, _1{}));
-  const bool q_nhd = ffpa_is_nhd_view(Q);
+  // Per-tensor layout families: BHND-packed, packed-NHD view, or
+  // strided-NHD (fused-QKV interleaved chunk rows, e.g. FLUX.2
+  // single-stream V). K and V must belong to the same family (the
+  // kernel's NHD batch/row domain-offset logic is shared), but their row
+  // strides may differ.
+  const bool q_nhd = ffpa_is_nhd_view(Q) || ffpa_is_strided_nhd(Q);
+  if (ffpa_is_strided_nhd(Q))
+    ffpa_check_strided_nhd_aligned(Q, "Q");
   if (!q_nhd) {
     TORCH_CHECK(Q.stride(3) == 1 && Q.stride(2) == (long)kHeadDim &&
                     Q.stride(1) == (long)Nq * kHeadDim &&
                     Q.stride(0) == (long)Nh * Nq * kHeadDim,
                 "ffpa_attn: Q must be BHND-contiguous or an NHD (BNHD) view");
   }
-  const bool kv_nhd = ffpa_is_nhd_view(K);
+  const bool k_nhd = ffpa_is_nhd_view(K) || ffpa_is_strided_nhd(K);
+  const bool v_nhd = ffpa_is_nhd_view(V) || ffpa_is_strided_nhd(V);
+  TORCH_CHECK(k_nhd == v_nhd,
+              "ffpa_attn: K and V must share the same memory layout family "
+              "(BHND-packed or NHD)");
+  if (ffpa_is_strided_nhd(K))
+    ffpa_check_strided_nhd_aligned(K, "K");
+  if (ffpa_is_strided_nhd(V))
+    ffpa_check_strided_nhd_aligned(V, "V");
+  const bool kv_nhd = k_nhd;
   if (!kv_nhd) {
     TORCH_CHECK(K.stride(3) == 1 && K.stride(2) == (long)kHeadDim &&
                     K.stride(1) == (long)Nkv * kHeadDim &&
@@ -627,9 +687,6 @@ void launch_cute_fwd_persist_d_sm120(torch::Tensor Q, torch::Tensor K,
                     V.stride(1) == (long)Nkv * kHeadDim &&
                     V.stride(0) == (long)Nh_kv * Nkv * kHeadDim,
                 "ffpa_attn: V must be BHND-contiguous or an NHD (BNHD) view");
-  } else {
-    TORCH_CHECK(ffpa_is_nhd_view(V),
-                "ffpa_attn: K and V must share the same memory layout");
   }
 
   // Everything from the TMA descriptor build through the kernel dispatch is
@@ -677,13 +734,15 @@ void launch_cute_fwd_persist_d_sm120(torch::Tensor Q, torch::Tensor K,
     }
   };
 
-  // Q TMA: BHND flat (B*H*N, D) rows or NHD flat (B*N, H*D) rows.
+  // Q TMA: BHND flat (B*H*N, D) rows or NHD flat (B*N, H*D) rows. NHD rows
+  // carry the tensor's own row stride: H*D for packed views, wider for
+  // strided fused-QKV chunk views.
   const auto make_tma_q = [&](auto q_c) {
     if constexpr (decltype(q_c)::value) {
       auto gQ =
           make_tensor(make_gmem_ptr(reinterpret_cast<Element*>(Q.data_ptr())),
                       make_shape((long)Nb * Nq, (long)Nh * kHeadDim),
-                      make_stride((long)Nh * kHeadDim, _1{}));
+                      make_stride(Q.stride(2), _1{}));
       return make_tma_copy(SM90_TMA_LOAD{}, gQ, SmemLayoutQ{},
                            Shape<Int<kBr>, Int<kHeadDim>>{}, _1{});
     } else {
@@ -699,17 +758,18 @@ void launch_cute_fwd_persist_d_sm120(torch::Tensor Q, torch::Tensor K,
   if (kv_nhd) {
     // NHD view [B, H, N, D] <- packed [B, N, H, D]: element offset is
     // ((b*N + n)*H + h)*D + d, i.e. a flat (B*N, H*D) row-major matrix with
-    // uniform row stride H*D. The kernel domain_offsets to the batch's rows
-    // and tiles the (H*D) columns by kHeadDim, so the head rides the second
-    // tile coord — same flat-2D TMA machinery as BHND.
+    // a uniform row stride (H*D packed; wider for strided fused-QKV chunk
+    // views). The kernel domain_offsets to the batch's rows and tiles the
+    // (H*D) columns by kHeadDim, so the head rides the second tile coord —
+    // same flat-2D TMA machinery as BHND.
     auto gK =
         make_tensor(make_gmem_ptr(reinterpret_cast<Element*>(K.data_ptr())),
                     make_shape((long)Nb * Nkv, (long)Nh_kv * kHeadDim),
-                    make_stride((long)Nh_kv * kHeadDim, _1{}));
+                    make_stride(K.stride(2), _1{}));
     auto gV =
         make_tensor(make_gmem_ptr(reinterpret_cast<Element*>(V.data_ptr())),
                     make_shape((long)Nb * Nkv, (long)Nh_kv * kHeadDim),
-                    make_stride((long)Nh_kv * kHeadDim, _1{}));
+                    make_stride(V.stride(2), _1{}));
     auto tma_k = make_tma_copy(SM90_TMA_LOAD{}, gK, SmemLayoutKV{},
                                Shape<Int<kBc>, Int<kHeadDim>>{}, _1{});
     auto tma_v = make_tma_copy(SM90_TMA_LOAD{}, gV, SmemLayoutKV{},
@@ -762,29 +822,32 @@ void launch_cute_fwd_persist_d_fp8_sm120_impl(
   // must all become kHeadDim-wide together.
   if (fp8_hadamard) {
     // WHT requires BHND-contiguous inputs; materialize packed copies for
-    // NHD views (rare combo — the quantize kernels below are NHD-native,
-    // only the WHT kernel is not). V must join the same packing: its
-    // readers derive the layout from K (Lkv), so pad it to kHeadDim or
-    // materialize it BHND when already wide.
-    if (ffpa_is_nhd_view(Q))
+    // any NHD-family view (rare combo — the quantize kernels below are
+    // NHD-native, only the WHT kernel is not). V must join the same
+    // packing: pad it to kHeadDim or materialize it BHND when already wide.
+    if (!Q.is_contiguous())
       Q = Q.contiguous();
-    if (ffpa_is_nhd_view(K))
+    if (!K.is_contiguous())
       K = K.contiguous();
     if (Q.size(3) < kHeadDim)
       V = torch::constant_pad_nd(V, {0, kHeadDim - Q.size(3)}, 0.0);
-    else if (ffpa_is_nhd_view(V))
+    else if (!V.is_contiguous())
       V = V.contiguous();
     Q = ffpa::apply_wht_qk_sm120<kDataType, kHeadDim>(Q);
     K = ffpa::apply_wht_qk_sm120<kDataType, kHeadDim>(K);
   }
   // NHD (diffusers BNHD) zero-copy views: the fp8 pre-kernels read the
   // original gmem through Fp8InputLayout strides, so no permute copy is
-  // needed. V must share K's layout (every V reader derives it from Lkv).
-  const ffpa_fp8::Fp8InputLayout Lq = ffpa_layout_of(Q, Q.size(2), Q.size(3));
-  const ffpa_fp8::Fp8InputLayout Lkv = ffpa_layout_of(K, K.size(2), K.size(3));
-  TORCH_CHECK(V.stride(0) == K.stride(0) && V.stride(1) == K.stride(1) &&
-                  V.stride(2) == K.stride(2) && V.stride(3) == K.stride(3),
-              "ffpa_attn: V must share K's memory layout");
+  // needed. Strided-NHD rows (fused-QKV chunk views, e.g. FLUX.2
+  // single-stream) are accepted via the relaxed gate; V keeps its own
+  // descriptor since interleaved chunks give it K's head layout but a
+  // wider row stride.
+  const ffpa_fp8::Fp8InputLayout Lq =
+      ffpa_layout_of(Q, Q.size(2), Q.size(3), /*allow_strided_rows=*/true);
+  const ffpa_fp8::Fp8InputLayout Lkv =
+      ffpa_layout_of(K, K.size(2), K.size(3), /*allow_strided_rows=*/true);
+  const ffpa_fp8::Fp8InputLayout Lv =
+      ffpa_layout_of(V, V.size(2), V.size(3), /*allow_strided_rows=*/true);
   TORCH_CHECK(attn_bias.numel() == 0 && dropout_p == 0.0,
               "fp8 sm120 path does not support attn_bias/dropout");
   // q/k only support per-block quant today; per-channel is reserved for
@@ -929,14 +992,14 @@ void launch_cute_fwd_persist_d_fp8_sm120_impl(
         reinterpret_cast<__nv_fp8_e4m3*>(vt8.data_ptr()),
         q_scale.data_ptr<float>(), k_scale.data_ptr<float>(),
         v_scale_quant.data_ptr<float>(), Nb, Nh, Nh_kv, Nq, Nkv, Nkv_pad, D_og,
-        Lq, Lkv, stream, km_ptr, reorg_free, v_per_channel);
+        Lq, Lkv, stream, km_ptr, reorg_free, v_per_channel, &Lv);
   } else {
     ffpa_fp8::launch_quantize_fp8_sm120<kDataType, kBr, kBc, kHeadDim, kQKInt8>(
         q_ptr, k_ptr, v_ptr, q8.data_ptr(), k8.data_ptr(),
         reinterpret_cast<__nv_fp8_e4m3*>(vt8.data_ptr()),
         q_scale.data_ptr<float>(), k_scale.data_ptr<float>(),
         v_scale_quant.data_ptr<float>(), Nb, Nh, Nh_kv, Nq, Nkv, Nkv_pad, D_og,
-        Lq, Lkv, stream, km_ptr, reorg_free, v_per_channel);
+        Lq, Lkv, stream, km_ptr, reorg_free, v_per_channel, &Lv);
   }
 
   // Per-channel V (sage-style): re-quantize V with per-D scale via coalesced
@@ -961,14 +1024,14 @@ void launch_cute_fwd_persist_d_fp8_sm120_impl(
           v_ptr, reinterpret_cast<__nv_fp8_e4m3*>(vt8.data_ptr()),
           v_scale.data_ptr<float>(), vm_ptr, v_partials_sum.data_ptr<float>(),
           v_partials_max.data_ptr<float>(), v_partials_min.data_ptr<float>(),
-          Nb, Nh_kv, Nkv, Nkv_pad, stream, D_og, v_r, reorg_free, &Lkv);
+          Nb, Nh_kv, Nkv, Nkv_pad, stream, D_og, v_r, reorg_free, &Lv);
     } else {
       ffpa_fp8::launch_quantize_fp8_vt_perchannel_sm120<kDataType, kBr, kBc,
                                                         kHeadDim, false>(
           v_ptr, reinterpret_cast<__nv_fp8_e4m3*>(vt8.data_ptr()),
           v_scale.data_ptr<float>(), vm_ptr, v_partials_sum.data_ptr<float>(),
           v_partials_max.data_ptr<float>(), v_partials_min.data_ptr<float>(),
-          Nb, Nh_kv, Nkv, Nkv_pad, stream, D_og, v_r, reorg_free, &Lkv);
+          Nb, Nh_kv, Nkv, Nkv_pad, stream, D_og, v_r, reorg_free, &Lv);
     }
   }
   const float* vm_kernel = v_smooth_mean ? vm_ptr : nullptr;
@@ -2006,18 +2069,21 @@ void launch_cute_fwd_persist_d_fp4_sm120_impl(
   const bool fused_wht = fp4_hadamard && kFuseWht;
   torch::Tensor km_rot_f32, qm_rot;
   if (fp4_hadamard && !fused_wht) {
-    // WHT pre-rotation needs BHND-packed rows; materialize NHD views.
-    if (ffpa_is_nhd_view(Q))
+    // WHT pre-rotation needs BHND-packed rows; materialize NHD-family views.
+    if (!Q.is_contiguous())
       Q = Q.contiguous();
-    if (ffpa_is_nhd_view(K))
+    if (!K.is_contiguous())
       K = K.contiguous();
     Q = ffpa::apply_wht_qk_sm120<kDataType, kHeadDim>(Q);
     K = ffpa::apply_wht_qk_sm120<kDataType, kHeadDim>(K);
   }
   const kDataType* k_ptr = reinterpret_cast<const kDataType*>(K.data_ptr());
-  // NHD (BNHD) permute views are consumed natively by the pre-kernels.
-  const ffpa_fp8::Fp8InputLayout Lkv = ffpa_layout_of(K, Nkv, K.size(3));
-  const ffpa_fp8::Fp8InputLayout Lv = ffpa_layout_of(V, Nkv, V.size(3));
+  // NHD (BNHD) permute views — including strided fused-QKV chunk rows —
+  // are consumed natively by the pre-kernels.
+  const ffpa_fp8::Fp8InputLayout Lkv =
+      ffpa_layout_of(K, Nkv, K.size(3), /*allow_strided_rows=*/true);
+  const ffpa_fp8::Fp8InputLayout Lv =
+      ffpa_layout_of(V, Nkv, V.size(3), /*allow_strided_rows=*/true);
 
   // Quantize kernels take (B,S,H,D)-strided inputs; pass the (B,H,N,D)
   // tensors as (B,N,H,D) views (strides only, no copy).

--- a/csrc/cuffpa/launch.cuh
+++ b/csrc/cuffpa/launch.cuh
@@ -51,6 +51,9 @@ static inline void prepare_hybrid_stage1(
       K_e = K.slice(2, 0, kv_offset + n_early).contiguous();
       V_e = V.slice(2, 0, kv_offset + n_early).contiguous();
     } else {
+      // Stage-1 runs the fp16 persist-D kernel, which consumes packed and
+      // strided-NHD K/V natively (split-D/m4n2 stage-1 variants are gated
+      // against strided inputs at dispatch).
       K_e = K;
       V_e = V;
     }
@@ -149,20 +152,37 @@ void launch_ffpa_attn_fwd_template(
   // permute+contiguous) instead of silently corrupting.
   bool nhd_in =
       ffpa_is_nhd_view(Q) || ffpa_is_nhd_view(K) || ffpa_is_nhd_view(V);
-  if (nhd_in && !force_fp8 && !force_fp4) {
-    auto prop_nhd = at::cuda::getCurrentDeviceProperties();
-    const bool fp16_nhd_ok = !force_tma && !force_native && !force_cute &&
-                             prop_nhd->major >= 12 && kHeadDim % 32 == 0 &&
-                             attn_bias.numel() == 0 && dropout_p == 0.0;
-    if (!fp16_nhd_ok) {
-      if (ffpa_is_nhd_view(Q))
-        Q = Q.contiguous();
-      if (ffpa_is_nhd_view(K))
-        K = K.contiguous();
-      if (ffpa_is_nhd_view(V))
-        V = V.contiguous();
-      nhd_in = false;
-    }
+  // Strided-NHD inputs (fused-QKV interleaved chunk views): neither
+  // BHND-packed nor a packed-NHD permute view.
+  const bool strided_in = (!ffpa_is_bhnd_packed(Q) && !ffpa_is_nhd_view(Q)) ||
+                          (!ffpa_is_bhnd_packed(K) && !ffpa_is_nhd_view(K)) ||
+                          (!ffpa_is_bhnd_packed(V) && !ffpa_is_nhd_view(V));
+  auto prop_nhd = at::cuda::getCurrentDeviceProperties();
+  const bool fp16_nhd_ok = !force_tma && !force_native && !force_cute &&
+                           prop_nhd->major >= 12 && kHeadDim % 32 == 0 &&
+                           attn_bias.numel() == 0 && dropout_p == 0.0;
+  if (nhd_in && !force_fp8 && !force_fp4 && !fp16_nhd_ok) {
+    if (ffpa_is_nhd_view(Q))
+      Q = Q.contiguous();
+    if (ffpa_is_nhd_view(K))
+      K = K.contiguous();
+    if (ffpa_is_nhd_view(V))
+      V = V.contiguous();
+    nhd_in = false;
+  }
+  // Strided-NHD inputs are consumed natively by the fp8/fp4 persist-D
+  // families (relaxed ffpa_layout_of gate) and the fp16 persist-D CUTE_TMA
+  // path (D<=128; split-D/M4N2 keep the strict gate); every other backend
+  // indexes packed storage and would silently mis-index. Materialize them
+  // the same way unsupported NHD views are materialized above.
+  const bool fp16_strided_ok = fp16_nhd_ok && kHeadDim <= 128;
+  if (strided_in && !force_fp8 && !force_fp4 && !fp16_strided_ok) {
+    if (!ffpa_is_bhnd_packed(Q) && !ffpa_is_nhd_view(Q))
+      Q = Q.contiguous();
+    if (!ffpa_is_bhnd_packed(K) && !ffpa_is_nhd_view(K))
+      K = K.contiguous();
+    if (!ffpa_is_bhnd_packed(V) && !ffpa_is_nhd_view(V))
+      V = V.contiguous();
   }
 #endif
 #endif
@@ -234,6 +254,16 @@ void launch_ffpa_attn_fwd_template(
             !(ffpa_is_nhd_view(O) && kHeadDim > 256),
             "ffpa_attn: NHD (BNHD) output requires the persist-D fp4 path "
             "(64 <= head_dim <= 256)");
+        // Strided-NHD inputs are consumed by the persist-D relaxed gate
+        // only; the split-D/m4n2 hybrid stage-1 fp16 kernels keep the
+        // strict gate, so reject that combination (mirrors fp8 D>224).
+        if constexpr (kHeadDim > 256) {
+          TORCH_CHECK(
+              !(strided_in && fp4_hybrid && Nq >= fp4_hybrid_n_early),
+              "ffpa_attn: strided-NHD input with fp4 hybrid requires the "
+              "persist-D path (head_dim <= 256); pass BHND-contiguous "
+              "tensors or disable hybrid");
+        }
         // NHD (BNHD) views are consumed natively by the fp4 pre-kernels and
         // the persist-D attention kernel (quantized buffers are BHND). The
         // persist-D hybrid stage-1 fp16 kernel also handles NHD K/V. Only
@@ -411,10 +441,12 @@ void launch_ffpa_attn_fwd_template(
 #ifdef ENABLE_FFPA_CUTE_EXT
 #ifdef ENABLE_FFPA_TMA_EXT
         if constexpr (kHeadDim > 224) {
-          TORCH_CHECK(!(nhd_in && fp8_hybrid && Nq >= fp8_hybrid_n_early),
-                      "ffpa_attn: NHD (BNHD) input with fp8 hybrid requires "
-                      "the persist-D path (head_dim <= 224); pass "
-                      "BHND-contiguous tensors or disable hybrid");
+          TORCH_CHECK(
+              !((nhd_in || strided_in) && fp8_hybrid &&
+                Nq >= fp8_hybrid_n_early),
+              "ffpa_attn: NHD (BNHD) or strided-NHD input with fp8 hybrid "
+              "requires the persist-D path (head_dim <= 224); pass "
+              "BHND-contiguous tensors or disable hybrid");
         }
 #endif
 #endif

--- a/src/ffpa_attn/__init__.py
+++ b/src/ffpa_attn/__init__.py
@@ -1,5 +1,12 @@
 from .ffpa_attn_interface import ffpa_attn_func, ffpa_attn_varlen_func
-from .functional import Backend, CUDABackend, CuTeDSLBackend, SDPABackend, TritonBackend
+from .functional import (
+  Backend,
+  CUDABackend,
+  CuTeDSLBackend,
+  SDPABackend,
+  TritonBackend,
+  is_nhd_zero_copy_input,
+)
 from .version import __version__
 
 __all__ = [
@@ -8,6 +15,7 @@ __all__ = [
   "CuTeDSLBackend",
   "SDPABackend",
   "TritonBackend",
+  "is_nhd_zero_copy_input",
   "ffpa_attn_func",
   "ffpa_attn_varlen_func",
   "__version__",

--- a/src/ffpa_attn/cuda/__init__.py
+++ b/src/ffpa_attn/cuda/__init__.py
@@ -106,8 +106,9 @@ def _fwd_cuda_torch_op(
     )
   # NHD (diffusers BNHD, tensor_layout=0): normalize Q/K/V to BHND-shape
   # NHD-storage views so every downstream size()/stride read keeps BHND
-  # semantics; O is allocated over NHD-packed storage (empty_like preserves
-  # the dense view strides) and returned in native [B, N, H, D].
+  # semantics; O is allocated over packed NHD storage (explicit strides:
+  # empty_like would inherit a strided NHD input's strides and the kernels
+  # would store O as BHND-packed into it) and returned in [B, N, H, D].
   # The layout stays a python-side permute (zero-copy) instead of a C++ flag:
   # with tensor_layout=1 a BHND-output call still legally takes NHD-view
   # inputs (zero-copy read path), a combination one flag cannot express, so
@@ -115,7 +116,10 @@ def _fwd_cuda_torch_op(
   # which packed layout a [B, H, N, D]-shaped tensor actually is.
   if tensor_layout == 0:
     Q, K, V = (t.permute(0, 2, 1, 3) for t in (Q, K, V))
-    O = torch.empty_like(Q)  # noqa: E741
+    B, H, N, D = Q.shape
+    O = torch.empty_strided(  # noqa: E741
+      (B, H, N, D), (N * H * D, D, H * D, 1), dtype=Q.dtype, device=Q.device
+    )
   else:
     # O must be BHND-packed even when Q is an NHD (diffusers BNHD) permute
     # view: empty_like would preserve the NHD strides, but the CUDA kernels
@@ -199,7 +203,11 @@ def _fwd_cuda_fake(
   tensor_layout: int = 1,
 ) -> tuple[torch.Tensor, torch.Tensor]:
   if tensor_layout == 0:
-    O = torch.empty_like(Q.permute(0, 2, 1, 3))  # noqa: E741
+    # Mirror the real op: packed-NHD storage returned as [B, N, H, D].
+    B, N, H, D = Q.shape
+    O = torch.empty_strided(  # noqa: E741
+      (B, N, H, D), (N * H * D, H * D, D, 1), dtype=Q.dtype, device=Q.device
+    )
     softmax_lse = Q.new_empty(
       Q.size(0), Q.size(2), Q.size(1), dtype=torch.float32
     )

--- a/src/ffpa_attn/functional.py
+++ b/src/ffpa_attn/functional.py
@@ -100,6 +100,35 @@ def _allow_cuda_small_d() -> bool:
   return _env_flag_enabled("FFPA_CUDA_ALLOW_SMALL_D")
 
 
+def is_nhd_zero_copy_input(t: torch.Tensor) -> bool:
+  """Whether a [B, N, H, D] tensor can feed the persist-D NHD path zero-copy.
+
+  Mirrors the relaxed ``ffpa_layout_of`` gate in ``csrc/cuffpa/cute/
+  launch.cuh``: packed-NHD tensors and fused-QKV interleaved chunk views
+  (row stride wider than ``H * D``) both qualify; BHND-packed and
+  arbitrary-stride tensors do not. Quant families whose C++ gate is not
+  relaxed yet must materialize tensors failing this predicate instead of
+  passing them through.
+
+  :param t: 4-D activation shaped ``[B, N, H, D]``.
+  :returns: True when the strides and 16B alignment satisfy the
+      strided-NHD layout contract.
+  """
+  if t.dim() != 4:
+    return False
+  B, N, H, D = t.shape
+  s_batch, s_row, s_head, s_d = t.stride()
+  if s_d != 1 or s_head != D or s_row < H * D:
+    return False
+  if B > 1 and s_batch != s_row * N:
+    return False
+  es = t.element_size()
+  return (
+    t.data_ptr() % 16 == 0 and (s_row * es) % 16 == 0
+    and (s_row * N * es) % 16 == 0
+  )
+
+
 def _backend_allows_small_d(backend: Backend, head_dim: int) -> bool:
   if not (_FFPA_SMALL_HEAD_DIM_MIN <= head_dim <= _ATEN_SMALL_HEAD_DIM_MAX):
     return False

--- a/tests/test_ffpa_nhd_layout.py
+++ b/tests/test_ffpa_nhd_layout.py
@@ -1,10 +1,12 @@
-"""NHD (diffusers BNHD) layout tests for the fp16 and fp4 persist-D kernels.
+"""NHD (diffusers BNHD) layout tests for the persist-D kernels.
 
 Each family runs the same attention twice — BHND-packed in/out and NHD
 packed in/out — and asserts the outputs agree bitwise (same kernel, only
 the O store coordinates differ). The NHD tensors are materialized
 NHD-packed ([B, N, H, D] contiguous) before the call, the documented
-construction that avoids false NHD views.
+construction that avoids false NHD views. The fp8 section additionally
+covers strided-NHD inputs (fused-QKV chunk views with row stride wider
+than H*D) consumed zero-copy through the relaxed layout gate.
 """
 
 import pytest
@@ -203,3 +205,243 @@ def test_nhd_layout_rejections(monkeypatch):
     ffpa_attn_func(
       _nhd(q), _nhd(k), _nhd(v), forward_backend=_backend(tensor_layout="NHD")
     )
+
+
+def _fused_qkv(B, H, Hkv, N, D, mlp=4096, dtype=torch.bfloat16):
+  """FLUX.2-style fused-QKV chunk views ([B, N, H, D] with row stride
+  ``R > H * D``): Q carved from a qkv+mlp projection row, K/V from a
+  kv+mlp row (GQA-safe: K/V carry ``Hkv`` heads)."""
+  R = 3 * H * D + mlp
+  proj = torch.randn(B, N, R, dtype=dtype, device="cuda") * 0.5
+  q = proj[..., 0:H * D].view(B, N, H, D)
+  Rkv = 2 * Hkv * D + mlp
+  kv = torch.randn(B, N, Rkv, dtype=dtype, device="cuda") * 0.5
+  k = kv[..., 0:Hkv * D].view(B, N, Hkv, D)
+  v = kv[..., Hkv * D:2 * Hkv * D].view(B, N, Hkv, D)
+  return q, k, v
+
+
+@pytest.mark.parametrize("causal", [False, True], ids=["dense", "causal"])
+@pytest.mark.parametrize(
+  "B,H,Hkv,N",
+  [(1, 24, 24, 2048), (1, 24, 24, 3000), (2, 8, 8, 2048), (1, 24, 6, 2048)],
+  ids=["full", "tail", "batch", "gqa"],
+)
+@pytest.mark.parametrize(
+  "vq", ["per_channel", "per_block"], ids=["vchan", "vblk"]
+)
+def test_fp8_strided_nhd_bit_exact(B, H, Hkv, N, vq, causal, monkeypatch):
+  """Strided-NHD (fused-QKV chunk) inputs read through the relaxed
+  ``ffpa_layout_of`` gate must match the packed-NHD and BHND runs bitwise:
+  the quantize pre-kernels are stride-generic, so only the addressing
+  differs. ``batch`` pins the batch-stride wiring, ``tail`` a partial
+  last tile."""
+  monkeypatch.setenv("FFPA_CUDA_ALLOW_SMALL_D", "1")
+  torch.manual_seed(0)
+  D = 128
+  q, k, v = _fused_qkv(B, H, Hkv, N, D)
+  assert not q.is_contiguous()
+  backend = _backend(enable_fp8=True, fp8_v_quant_method=vq)
+  backend_nhd = _backend(
+    enable_fp8=True, fp8_v_quant_method=vq, tensor_layout="NHD"
+  )
+  with torch.no_grad():
+    out_b = ffpa_attn_func(
+      q.permute(0, 2, 1, 3).contiguous(),
+      k.permute(0, 2, 1, 3).contiguous(),
+      v.permute(0, 2, 1, 3).contiguous(),
+      is_causal=causal,
+      forward_backend=backend,
+    )
+    out_s = ffpa_attn_func(
+      q, k, v, is_causal=causal, forward_backend=backend_nhd
+    )
+    out_n = ffpa_attn_func(
+      q.contiguous(),
+      k.contiguous(),
+      v.contiguous(),
+      is_causal=causal,
+      forward_backend=backend_nhd,
+    )
+  assert out_s.shape == (B, N, H, D) and out_s.is_contiguous()
+  assert torch.equal(out_s, out_n)
+  assert torch.equal(out_s, out_b.permute(0, 2, 1, 3))
+
+
+@pytest.mark.parametrize("causal", [False, True], ids=["dense", "causal"])
+@pytest.mark.parametrize(
+  "B,H,Hkv,N",
+  [(1, 24, 24, 2048), (2, 8, 8, 2048), (1, 24, 6, 2048)],
+  ids=["full", "batch", "gqa"],
+)
+def test_fp16_strided_nhd_bit_exact(B, H, Hkv, N, causal, monkeypatch):
+  """fp16 persist-D stride-parameterized TMA descriptors read strided
+  fused-QKV views zero-copy; K/V stay in the same NHD family with
+  different row strides (the FLUX.2 shape)."""
+  monkeypatch.setenv("FFPA_CUDA_ALLOW_SMALL_D", "1")
+  torch.manual_seed(0)
+  D = 128
+  q, k, v = _fused_qkv(B, H, Hkv, N, D)
+  with torch.no_grad():
+    out_s = ffpa_attn_func(
+      q, k, v, is_causal=causal, forward_backend=_backend(tensor_layout="NHD")
+    )
+    out_n = ffpa_attn_func(
+      q.contiguous(),
+      k.contiguous(),
+      v.contiguous(),
+      is_causal=causal,
+      forward_backend=_backend(tensor_layout="NHD"),
+    )
+  assert out_s.shape == (B, N, H, D) and out_s.is_contiguous()
+  assert torch.equal(out_s, out_n)
+
+
+@pytest.mark.parametrize("causal", [False, True], ids=["dense", "causal"])
+@pytest.mark.parametrize("D", [128, 192], ids=["d128-fused", "d192-sep"])
+def test_fp4_strided_nhd_bit_exact(D, causal, monkeypatch):
+  """fp4 persist-D relaxed gate: fused (D<=128) and separate (D>128)
+  quantize chains both read strided fused-QKV views zero-copy."""
+  monkeypatch.setenv("FFPA_CUDA_ALLOW_SMALL_D", "1")
+  torch.manual_seed(0)
+  B, H, N = 1, 24, 2048
+  q, k, v = _fused_qkv(B, H, H, N, D)
+  kw = dict(enable_fp4=True, fp4_hybrid=False)
+  with torch.no_grad():
+    out_s = ffpa_attn_func(
+      q,
+      k,
+      v,
+      is_causal=causal,
+      forward_backend=_backend(tensor_layout="NHD", **kw)
+    )
+    out_n = ffpa_attn_func(
+      q.contiguous(),
+      k.contiguous(),
+      v.contiguous(),
+      is_causal=causal,
+      forward_backend=_backend(tensor_layout="NHD", **kw),
+    )
+  assert out_s.shape == (B, N, H, D) and out_s.is_contiguous()
+  assert torch.equal(out_s, out_n)
+
+
+def test_fp4_strided_nhd_batch2(monkeypatch):
+  """B=2 pins the batch-stride wiring of the fp4 pre-kernels/delta_s."""
+  monkeypatch.setenv("FFPA_CUDA_ALLOW_SMALL_D", "1")
+  torch.manual_seed(0)
+  B, H, N, D = 2, 8, 2048, 128
+  q, k, v = _fused_qkv(B, H, H, N, D, mlp=1024)
+  kw = dict(enable_fp4=True, fp4_hybrid=False)
+  with torch.no_grad():
+    out_s = ffpa_attn_func(
+      q, k, v, forward_backend=_backend(tensor_layout="NHD", **kw)
+    )
+    out_n = ffpa_attn_func(
+      q.contiguous(),
+      k.contiguous(),
+      v.contiguous(),
+      forward_backend=_backend(tensor_layout="NHD", **kw),
+    )
+  assert torch.equal(out_s, out_n)
+
+
+@pytest.mark.parametrize("causal", [False, True], ids=["dense", "causal"])
+def test_fp8_hybrid_strided_nhd_bit_exact(causal, monkeypatch):
+  """Hybrid + strided: stage-1 materializes the strided K/V for the fp16
+  kernel (shared ``prepare_hybrid_stage1`` fallback), stage-2 reads the
+  originals zero-copy — the result still matches bitwise."""
+  monkeypatch.setenv("FFPA_CUDA_ALLOW_SMALL_D", "1")
+  torch.manual_seed(0)
+  B, H, N, D = 1, 24, 2048, 128
+  q, k, v = _fused_qkv(B, H, H, N, D)
+  kw = dict(enable_fp8=True, fp8_hybrid=True, fp8_hybrid_n_early=256)
+  with torch.no_grad():
+    out_s = ffpa_attn_func(
+      q,
+      k,
+      v,
+      is_causal=causal,
+      forward_backend=_backend(tensor_layout="NHD", **kw)
+    )
+    out_n = ffpa_attn_func(
+      q.contiguous(),
+      k.contiguous(),
+      v.contiguous(),
+      is_causal=causal,
+      forward_backend=_backend(tensor_layout="NHD", **kw),
+    )
+  assert torch.equal(out_s, out_n)
+
+
+def test_fp8_hadamard_strided_nhd_bit_exact(monkeypatch):
+  """Hadamard + strided: the WHT path materializes non-contiguous inputs
+  (safe copy path), output stays bitwise-equal to the packed run."""
+  monkeypatch.setenv("FFPA_CUDA_ALLOW_SMALL_D", "1")
+  torch.manual_seed(0)
+  B, H, N, D = 1, 24, 2048, 128
+  q, k, v = _fused_qkv(B, H, H, N, D)
+  kw = dict(enable_fp8=True, fp8_hadamard=True)
+  with torch.no_grad():
+    out_s = ffpa_attn_func(
+      q, k, v, forward_backend=_backend(tensor_layout="NHD", **kw)
+    )
+    out_n = ffpa_attn_func(
+      q.contiguous(),
+      k.contiguous(),
+      v.contiguous(),
+      forward_backend=_backend(tensor_layout="NHD", **kw),
+    )
+  assert torch.equal(out_s, out_n)
+
+
+def test_fp8_strided_nhd_rejections(monkeypatch):
+  """Layouts outside the relaxed contract must fail loudly (never
+  silently mis-index): unaligned row strides, a broken batch stride at
+  B>1, and head-overlapping rows (``stride(row) < H*D``)."""
+  from ffpa_attn import is_nhd_zero_copy_input
+
+  monkeypatch.setenv("FFPA_CUDA_ALLOW_SMALL_D", "1")
+  torch.manual_seed(0)
+  B, N, H, D = 1, 1024, 8, 128
+
+  def _views(t, Bv, Nv):
+    return (
+      t[..., 0:H * D].view(Bv, Nv, H, D),
+      t[..., H * D:2 * H * D].view(Bv, Nv, H, D),
+      t[..., 2 * H * D:3 * H * D].view(Bv, Nv, H, D),
+    )
+
+  def _reject(q, k, v, match):
+    assert not is_nhd_zero_copy_input(q)
+    with pytest.raises(RuntimeError, match=match):
+      with torch.no_grad():
+        ffpa_attn_func(
+          q,
+          k,
+          v,
+          forward_backend=_backend(enable_fp8=True, tensor_layout="NHD")
+        )
+
+  # Row stride 3*H*D + 5 elements is not 16B-aligned for bf16.
+  t = torch.randn(B, N, 3 * H * D + 5, dtype=torch.bfloat16, device="cuda")
+  _reject(*_views(t, B, N), "16B-aligned")
+  # B=2 with gap rows between batches: batch stride != N * row stride.
+  gap = 8
+  big = torch.randn(2 * N + gap, 3 * H * D, dtype=torch.bfloat16, device="cuda")
+  st = ((N + gap) * 3 * H * D, 3 * H * D, D, 1)
+  _reject(
+    torch.as_strided(big, (2, N, H, D), st),
+    torch.as_strided(big[:, H * D:], (2, N, H, D), st),
+    torch.as_strided(big[:, 2 * H * D:], (2, N, H, D), st),
+    "permute view",
+  )
+  # Rows narrower than H*D interleave heads.
+  narrow = torch.randn(B, N * H * D, dtype=torch.bfloat16, device="cuda")
+  ov = (N * H * D, H * D - 8, D, 1)
+  _reject(
+    torch.as_strided(narrow, (B, N, H, D), ov),
+    torch.as_strided(narrow, (B, N, H, D), ov),
+    torch.as_strided(narrow, (B, N, H, D), ov),
+    "permute view",
+  )


### PR DESCRIPTION
Relax the ffpa_layout_of gate so NHD views whose rows are packed (H*D) but whose row stride is larger (e.g. chunk views of fused QKV+MLP projections in FLUX.2 single-stream blocks) are consumed directly, matching SageAttention's zero-copy behavior.

- add ffpa_is_bhnd_packed / ffpa_is_strided_nhd / alignment-check helpers; ffpa_layout_of gains allow_strided_rows and requires s_row >= H*D, positive batch stride, and 16B alignment
- fp8/fp4 persist-D: build an independent Lv descriptor for V and thread it through the quantize/VT pre-kernels (optional Lv tail param; split-D/M4N2 callers fall back to Lkv); hadamard now materializes on !is_contiguous()
- fp16 persist-D (CUTE_TMA, D<=128): per-tensor nhd flags allow mixed layouts; TMA box row stride is taken from X.stride(2) instead of hardcoded N*H*D
- scheduler materializes strided inputs once for families/paths that cannot consume them (native backend fallback); fp4/fp8 split-D hybrid rejects strided input
- O allocation uses torch.empty_strided with explicit packed-NHD strides (empty_like would inherit strided Q storage and corrupt silently); fake op mirrored
- python: is_nhd_zero_copy_input() mirrors the C++ gate for backend-side fast-path decisions
- tests: +34 strided-NHD cases (fp8/fp4/fp16, hybrid, hadamard, rejections); layout suite now 63 passed

Verified on FLUX.2-klein-9B edit 1024x1024 (PRO 5000, sm_120f): all 24 single-stream blocks consume fused-chunk V (row stride 36864) with zero copies (nsys-confirmed), e2e ffpa_fp8 6.44s == sage 6.44s, output matches sage (mean pixel diff 2.6).