### PR TITLE
chore(deps): bump CUTLASS DSL to 4.6.2 and quack-kernels to 0.6.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ dependencies = [
     "numpy",
     "ray", # autotuning
     "torch>=2.10.0",
-    "quack-kernels==0.6.1",
-    "nvidia-cutlass-dsl==4.6.0",
+    "quack-kernels==0.6.4",
+    "nvidia-cutlass-dsl==4.6.2",
     "apache-tvm-ffi>=0.1.11,<0.2",
 ]
 


### PR DESCRIPTION
Bumps the two exact pins in `[project].dependencies`:

```diff
-    "quack-kernels==0.6.1",
-    "nvidia-cutlass-dsl==4.6.0",
+    "quack-kernels==0.6.4",
+    "nvidia-cutlass-dsl==4.6.2",
```

They move together because `quack-kernels` pins CUTLASS DSL exactly: 0.6.1 → `==4.6.0`, 0.6.4 → `==4.6.2`. Bumping either alone is unsatisfiable.

### Motivation

`ffpa-attn` currently cannot be co-installed with FlashAttention-4. `flash_attn/cute` requires `nvidia-cutlass-dsl>=4.6.2`, and both packages `import cutlass`, so a single environment has to agree on one version. The `==4.6.0` pin here makes that resolution impossible.

This came up integrating both into [NVIDIA NeMo AutoModel](https://github.com/NVIDIA-NeMo/Automodel), where `ffpa-attn` backs a context-parallel ring-attention path and FA4 is the Blackwell attention backend. Downstream we currently have to force the versions with resolver overrides, which means `ffpa-attn` runs against versions it doesn't declare — hence this PR.

Nothing in #283's rationale blocks the bump: that pin was about pairing with `apache-tvm-ffi` 0.1.11 for the `map_dataclass_to_tuple` fix, and 4.6.2 postdates it. The existing `apache-tvm-ffi>=0.1.11,<0.2` range is unaffected — `quack-kernels` 0.6.4 asks for `>=0.1.6,<0.2`, so it stays compatible.

### Verification

I don't have a GPU to run the kernels on, so this is **static verification only** — a maintainer should confirm on hardware before merging.

**Every symbol this repo imports from both packages is unchanged between the pinned and bumped versions.** Checked by extracting the wheels and comparing:

`quack` (from `src/ffpa_attn/cute/`) — modules `copy_utils`, `layout_utils`, `sm90_utils`, `compile_utils`, `cute_dsl_utils`, `activation`; symbols `make_fake_tensor`, `ParamsBase`, `gemm_w_idx`. All present in 0.6.1 and 0.6.4.

`cutlass` — modules `cute`, `cute.nvgpu`, `cute.typing`, `utils`, `pipeline`, `base_dsl`, `utils/hopper_helpers.py`, `utils/blackwell_helpers.py`; symbols `FastDivmodDivisor`, `LayoutEnum`, `pipeline_init_arrive`, `pipeline_init_wait`, `CooperativeGroup`, `OperandMajorMode`, `from_dlpack`, `const_expr`. All present in 4.6.0 and 4.6.2.

The bumped set also resolves cleanly:

```
$ uv pip compile  # quack-kernels==0.6.4, nvidia-cutlass-dsl==4.6.2, apache-tvm-ffi>=0.1.11,<0.2
apache-tvm-ffi==0.1.13.post3
nvidia-cutlass-dsl==4.6.2
nvidia-cutlass-dsl-libs-base==4.6.2
nvidia-cutlass-dsl-libs-core==4.6.2
nvidia-cutlass-dsl-libs-cu12==4.6.2
quack-kernels==0.6.4
```

### Alternative

If you'd rather not chase `quack-kernels` releases, relaxing to `quack-kernels>=0.6.1` and dropping the `nvidia-cutlass-dsl` line entirely would also work — `quack-kernels` already constrains CUTLASS DSL exactly, so the second pin is redundant and is what actually causes the conflict. Happy to switch this PR to that shape if you prefer; I went with the straight bump to match the existing convention.