### PR TITLE
fix(sm90): skip dQ epilogue for keyless tiles

### DIFF
--- a/src/ffpa_attn/cute/_dq_d384_sm90.py
+++ b/src/ffpa_attn/cute/_dq_d384_sm90.py
@@ -1269,9 +1269,9 @@ class FFPAAttnBwdDQSm90SplitDD384:
       m_block, head_idx, batch_idx, _ = work_tile.tile_idx
       seqlen = SeqlenInfoCls(batch_idx)
       n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block)
-      process_tile = const_expr(
-        not self.is_varlen_k
-      ) or n_block_min < n_block_max
+      # A keyless tile has no MMA producer for the dQ accumulators. Keep the
+      # wrapper-prezeroed dQ instead of epiloguing undefined RMEM fragments.
+      process_tile = n_block_min < n_block_max
 
       mask = AttentionMask(self.tile_m, self.tile_n, seqlen)
 
@@ -1633,9 +1633,8 @@ class FFPAAttnBwdDQSm90SplitDD384:
       seqlen = SeqlenInfoCls(batch_idx)
       n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block)
 
-      process_tile = const_expr(
-        not self.is_varlen_k
-      ) or n_block_min < n_block_max
+      # Mirror WG1: both halves must agree whether a defined accumulator exists.
+      process_tile = n_block_min < n_block_max
 
       mask = AttentionMask(self.tile_m, self.tile_n, seqlen)
 

--- a/src/ffpa_attn/cute/_dq_d512_sm90.py
+++ b/src/ffpa_attn/cute/_dq_d512_sm90.py
@@ -1089,9 +1089,9 @@ class FFPAAttnBwdDQSm90SplitD:
       m_block, head_idx, batch_idx, _ = work_tile.tile_idx
       seqlen = SeqlenInfoCls(batch_idx)
       n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block)
-      process_tile = const_expr(
-        not self.is_varlen_k
-      ) or n_block_min < n_block_max
+      # A keyless tile has no MMA producer for the dQ accumulators.  Keep the
+      # wrapper-prezeroed dQ instead of epiloguing undefined RMEM fragments.
+      process_tile = n_block_min < n_block_max
 
       mask = AttentionMask(self.tile_m, self.tile_n, seqlen)
 
@@ -1421,9 +1421,8 @@ class FFPAAttnBwdDQSm90SplitD:
       seqlen = SeqlenInfoCls(batch_idx)
       n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block)
 
-      process_tile = const_expr(
-        not self.is_varlen_k
-      ) or n_block_min < n_block_max
+      # Mirror WG1: both halves must agree whether a defined accumulator exists.
+      process_tile = n_block_min < n_block_max
 
       mask = AttentionMask(self.tile_m, self.tile_n, seqlen)
 


### PR DESCRIPTION
## Summary

Fix the SM90 D384/D512 dQ kernels to process a query tile only when it has
at least one valid KV block:

```cpp
process_tile = n_block_min < n_block_max;
```

This prevents keyless causal tiles from epiloguing undefined dQ accumulators
and preserves the pre-zeroed gradient output.

## Motivation

Existing training workloads were unaffected:

- The public dense causal API requires `Nkv >= Nq`.
- Varlen training already uses the runtime block-range check.

This change therefore acts as stricter kernel-level validation and hardening
for internal or future call paths.

## Testing

Validated on **H100 (SM90)** with:

- [x] FP16 / BF16
- [x] Head dims D320–D512
- [x] Varlen configurations
- [x] Multiple batch / head configurations
