### PR TITLE
fix(cute): remove varlen host syncs and retire cross-process cache

### DIFF
--- a/src/ffpa_attn/cute/__init__.py
+++ b/src/ffpa_attn/cute/__init__.py
@@ -47,7 +47,6 @@ from ._utils import (
   _validate_training_dtype,
   _validate_varlen_custom_bwd_features,
   _validate_varlen_custom_fwd_features,
-  is_fake_mode,
 )
 from ._ffpa_fwd_sm80 import _ffpa_attn_forward_sm80
 from ._ffpa_fwd_sm90 import _ffpa_attn_forward_sm90
@@ -761,32 +760,11 @@ def _bwd_cute_fake(
 # Varlen torch custom ops — ``@custom_op`` + ``@register_fake`` +
 # ``register_autograd`` pattern.  The varlen path owns its own autograd
 # boundary (unlike dense, which delegates to ``_FFPAAttnFunc``).
+#
+# Zero-length ``cu_seqlens`` segments (leading/interior/trailing) are part
+# of the op contract and run as zero-work tiles in the kernels; the host
+# never inspects prefix values, so no per-call device→host sync.
 # ---------------------------------------------------------------------------
-
-
-def _trim_trailing_empty_varlen_segments(
-  cu_seqlens_q: torch.Tensor,
-  cu_seqlens_k: torch.Tensor,
-) -> tuple[torch.Tensor, torch.Tensor]:
-  """Drop trailing segments where both q and k have zero length."""
-  if cu_seqlens_q.numel() != cu_seqlens_k.numel():
-    return cu_seqlens_q, cu_seqlens_k
-  if cu_seqlens_q.numel() <= 1 or is_fake_mode():
-    return cu_seqlens_q, cu_seqlens_k
-
-  q_lengths = cu_seqlens_q[1:] - cu_seqlens_q[:-1]
-  k_lengths = cu_seqlens_k[1:] - cu_seqlens_k[:-1]
-  active = (q_lengths != 0) | (k_lengths != 0)
-  if bool(active.all().item()):
-    return cu_seqlens_q, cu_seqlens_k
-  if not bool(active.any().item()):
-    return cu_seqlens_q[:1], cu_seqlens_k[:1]
-
-  last_active_segment = int(active.nonzero()[-1].item())
-  keep_numel = last_active_segment + 2
-  if keep_numel == cu_seqlens_q.numel():
-    return cu_seqlens_q, cu_seqlens_k
-  return cu_seqlens_q[:keep_numel], cu_seqlens_k[:keep_numel]
 
 
 @torch.library.custom_op("ffpa_attn::_varlen_fwd_cute", mutates_args=())
@@ -805,9 +783,6 @@ def _varlen_fwd_custom(
   softcap: float,
   pack_gqa: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-  cu_seqlens_q, cu_seqlens_k = _trim_trailing_empty_varlen_segments(
-    cu_seqlens_q, cu_seqlens_k
-  )
   window_size_left_opt, window_size_right_opt = _decode_custom_op_window(
     window_size_left, window_size_right
   )
@@ -903,9 +878,6 @@ def _varlen_bwd_custom(
   softcap: float,
   dlse: Optional[torch.Tensor],
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-  cu_seqlens_q, cu_seqlens_k = _trim_trailing_empty_varlen_segments(
-    cu_seqlens_q, cu_seqlens_k
-  )
   window_size_left_opt, window_size_right_opt = _decode_custom_op_window(
     window_size_left, window_size_right
   )

--- a/src/ffpa_attn/cute/_ffpa_fwd_sm100.py
+++ b/src/ffpa_attn/cute/_ffpa_fwd_sm100.py
@@ -20,7 +20,7 @@ from ._utils import (
   _validate_training_dtype,
 )
 from ._fwd_d512_sm100 import FFPAAttnFwdSm100D512, compile_key_fields
-from .utils import AuxData, fa_logging
+from .utils import fa_logging
 from .utils.cache_utils import get_jit_cache
 from .utils.cute_dsl_utils import to_cute_tensor
 from .utils.fa_logging import fa_log
@@ -247,7 +247,7 @@ def _ffpa_attn_forward_sm100(
       None,  # learnable_sink
       None,  # descale_tensors
       None,  # blocksparse_tensors
-      AuxData(),
+      None,  # aux_data
       current_stream,
       options=_PTXAS,
     )

--- a/src/ffpa_attn/cute/_fwd_d512_sm100.py
+++ b/src/ffpa_attn/cute/_fwd_d512_sm100.py
@@ -372,7 +372,7 @@ class FFPAAttnFwdSm100D512(IketTraceChannel):
     learnable_sink: Optional[cute.Tensor] = None,
     descale_tensors: Optional[DescaleTensors] = None,
     blocksparse_tensors: Optional[cute.Tensor] = None,
-    aux_data: AuxData = AuxData(),
+    aux_data: Optional[AuxData] = None,
     stream: cuda.CUstream = None,
   ):
     """Trace entry; mirrors FlashAttentionForwardSm100.__call__'s interface."""
@@ -385,10 +385,10 @@ class FFPAAttnFwdSm100D512(IketTraceChannel):
     assert blocksparse_tensors is None, (
       "SM100 forward with head_dim=512 does not support block sparse tensors"
     )
-    assert aux_data.tensors is None, (
+    assert aux_data is None or aux_data.tensors is None, (
       "SM100 forward with head_dim=512 does not support aux_tensors"
     )
-    assert aux_data.scalars is None, (
+    assert aux_data is None or aux_data.scalars is None, (
       "SM100 forward with head_dim=512 does not support aux_scalars"
     )
     assert not self.is_local, (

--- a/src/ffpa_attn/cute/_utils.py
+++ b/src/ffpa_attn/cute/_utils.py
@@ -412,17 +412,17 @@ def _validate_cu_seqlens(
   if not tensor.is_cuda:
     raise RuntimeError(f"{name} must be on a CUDA device, got {tensor.device}")
 
-  first = int(tensor[0].item())
-  if first != 0:
-    raise ValueError(f"{name}[0] must be 0, got {first}")
+  # Exact device-value guards, asynchronous (``.item()`` would sync per
+  # call); violations trap as a device-side assert, not a ValueError.
+  ok = tensor[0] == 0
+  message = f"{name} must satisfy: [0] == 0"
   if total_tokens is not None:
-    last = int(tensor[-1].item())
-    if last != total_tokens:
-      raise ValueError(
-        f"{name}[-1] must equal total tokens ({total_tokens}), got {last}"
-      )
-  if tensor.numel() > 1 and bool(torch.any(tensor[1:] < tensor[:-1]).item()):
-    raise ValueError(f"{name} must be monotonically non-decreasing")
+    ok = ok & (tensor[-1] == total_tokens)
+    message += f", [-1] == total tokens ({total_tokens})"
+  if tensor.numel() > 1:
+    ok = ok & torch.all(tensor[1:] >= tensor[:-1])
+    message += ", monotonically non-decreasing"
+  torch._assert_async(ok, message)
 
 
 def _validate_max_seqlen_for_cu_seqlens(
@@ -442,11 +442,14 @@ def _validate_max_seqlen_for_cu_seqlens(
     return
 
   lengths = tensor[1:] - tensor[:-1]
-  actual_max = int(lengths.max().item()) if lengths.numel() > 0 else 0
-  if max_seqlen < actual_max:
-    raise ValueError(
-      f"{max_name} ({max_seqlen}) must be >= max sequence length from {name} ({actual_max})"
-    )
+  if lengths.numel() == 0:
+    return
+  # Async device-side guard (``.item()`` would sync per call): an undersized
+  # max_seqlen would shrink the launch grid and silently yield garbage rows.
+  torch._assert_async(
+    (lengths.max() <= max_seqlen),
+    f"{max_name} ({max_seqlen}) must be >= the max sequence length in {name}",
+  )
 
 
 def _ensure_cuda_tensors(*named_tensors) -> None:

--- a/src/ffpa_attn/cute/utils/cache_utils.py
+++ b/src/ffpa_attn/cute/utils/cache_utils.py
@@ -1,155 +1,31 @@
-# This file is copied from https://github.com/Dao-AILab/flash-attention/blob/main/flash_attn/cute/cache_utils.py
-# Manage Ahead-of-Time (AOT) compiled kernels
-import fcntl
-import hashlib
+# Derived from https://github.com/Dao-AILab/flash-attention/blob/main/flash_attn/cute/cache_utils.py
+# Compiled-kernel cache: an in-process dict of ``JitCompiledFunction``
+# wrappers.  Cross-process persistence is retired: raw ``export_to_c``
+# callables expose the fixed parameter ABI and crash
+# wrapper-convention call sites (``TypeError: Expects 17 parameters``),
+# and the CUTE DSL file cache cannot take over while ``cute.compile``
+# hardcodes ``no_cache=True``.
 import os
-import pickle
-import sys
-import tempfile
-import time
-from functools import lru_cache
-from getpass import getuser
-from pathlib import Path
+import warnings
 from typing import Hashable, TypeAlias
 
-import ctypes
-
-import cutlass
-import cutlass.cute as cute
-import tvm_ffi
 from cutlass.cutlass_dsl import JitCompiledFunction
-from .fa_logging import fa_log
-
-# Pre-load cute DSL runtime libraries with RTLD_GLOBAL so that their symbols
-# (e.g. _cudaLibraryLoadData) are visible to .so modules loaded later via dlopen.
-# Upstream cute.runtime.load_module loads these without RTLD_GLOBAL, which causes
-# "undefined symbol" errors when loading cached kernels from disk.
-for _lib_path in cute.runtime.find_runtime_libraries(enable_tvm_ffi=False):
-  if Path(_lib_path).exists():
-    ctypes.CDLL(_lib_path, mode=ctypes.RTLD_GLOBAL)
 
 CompileKeyType: TypeAlias = tuple[Hashable, ...]
-CallableFunction: TypeAlias = JitCompiledFunction | tvm_ffi.Function
 
-# Enable cache via `FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1`
+# Inert legacy flag; FLASH_ATTENTION_CUTE_DSL_CACHE_DIR is likewise ignored.
+# Warn rather than log: setting it is a request for persistence that no
+# longer exists, and the operator must hear that at the default verbosity.
 CUTE_DSL_CACHE_ENABLED: bool = os.getenv(
   "FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED", "0"
 ) == "1"
-
-# Customize cache dir via `FLASH_ATTENTION_CUTE_DSL_CACHE_DIR`, default is
-# `/tmp/${USER}/flash_attention_cute_dsl_cache``
-CUTE_DSL_CACHE_DIR: str | None = os.getenv(
-  "FLASH_ATTENTION_CUTE_DSL_CACHE_DIR", None
-)
-
-
-def get_cache_path() -> Path:
-  if CUTE_DSL_CACHE_DIR is not None:
-    cache_dir = Path(CUTE_DSL_CACHE_DIR)
-  else:
-    cache_dir = Path(tempfile.gettempdir()
-                     ) / getuser() / "flash_attention_cute_dsl_cache"
-  cache_dir.mkdir(parents=True, exist_ok=True)
-  return cache_dir
-
-
-@lru_cache(maxsize=1)
-def _compute_source_fingerprint() -> str:
-  """
-    Hash all CuTe Python sources plus runtime ABI stamps into a short fingerprint.
-
-    The fingerprint changes whenever:
-    - Any .py file under ffpa_attn/cutedsl is added, removed, renamed, or modified.
-    - The Python minor version changes (e.g. 3.13 -> 3.14).
-    - The cutlass or tvm_ffi package version changes.
-
-    Computed once per process and cached.
-    """
-  # Walk the cutedsl/ package, not just utils/, so kernel source changes also
-  # invalidate the on-disk cache. __file__ here is cutedsl/utils/cache_utils.py.
-  cute_root = Path(__file__).resolve().parent.parent
-  h = hashlib.sha256()
-
-  h.update(f"py{sys.version_info.major}.{sys.version_info.minor}".encode())
-  h.update(f"cutlass={cutlass.__version__}".encode())
-  h.update(f"tvm_ffi={tvm_ffi.__version__}".encode())
-
-  for src in sorted(cute_root.rglob("*.py")):
-    if not src.is_file():
-      continue
-    h.update(src.relative_to(cute_root).as_posix().encode())
-    content = src.read_bytes()
-    h.update(len(content).to_bytes(8, "little"))
-    h.update(content)
-
-  return h.hexdigest()
-
-
-class FileLock:
-  """Context manager for advisory file locks using fcntl.flock.
-
-    Supports exclusive (write) and shared (read) locks.
-    Always blocks with polling until the lock is acquired or timeout is reached.
-
-    Usage:
-        with FileLock(lock_path, exclusive=True, timeout=15, label="abc"):
-            # do work under lock
-    """
-
-  def __init__(
-    self,
-    lock_path: Path,
-    exclusive: bool,
-    timeout: float = 15,
-    label: str = "",
-  ):
-    """
-        Args:
-            lock_path: Path to the lock file on disk.
-            exclusive: True for exclusive (write) lock, False for shared (read) lock.
-            timeout: Max seconds to wait for lock acquisition before raising RuntimeError.
-            label: Optional human-readable label for error messages.
-        """
-    self.lock_path: Path = lock_path
-    self.exclusive: bool = exclusive
-    self.timeout: float = timeout
-    self.label: str = label
-    self._fd: int = -1
-
-  @property
-  def _lock_label(self) -> str:
-    kind = "exclusive" if self.exclusive else "shared"
-    return f"{kind} {self.label}" if self.label else kind
-
-  def __enter__(self) -> "FileLock":
-    open_flags = os.O_WRONLY | os.O_CREAT if self.exclusive else os.O_RDONLY | os.O_CREAT
-    lock_type = fcntl.LOCK_EX if self.exclusive else fcntl.LOCK_SH
-
-    self._fd = os.open(str(self.lock_path), open_flags)
-
-    deadline = time.monotonic() + self.timeout
-    acquired = False
-    while time.monotonic() < deadline:
-      try:
-        fcntl.flock(self._fd, lock_type | fcntl.LOCK_NB)
-        acquired = True
-        break
-      except OSError:
-        time.sleep(0.1)
-    if not acquired:
-      os.close(self._fd)
-      self._fd = None
-      raise RuntimeError(
-        f"Timed out after {self.timeout}s waiting for {self._lock_label} lock: {self.lock_path}"
-      )
-
-    return self
-
-  def __exit__(self, exc_type, exc_val, exc_tb) -> None:
-    if self._fd is not None:
-      fcntl.flock(self._fd, fcntl.LOCK_UN)
-      os.close(self._fd)
-      self._fd = None
+if CUTE_DSL_CACHE_ENABLED:
+  warnings.warn(
+    "FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1 is inert: cross-process kernel "
+    "persistence was removed, so the compiled-kernel cache is in-process only "
+    "and FLASH_ATTENTION_CUTE_DSL_CACHE_DIR is ignored.",
+    UserWarning,
+  )
 
 
 class JITCache:
@@ -158,12 +34,12 @@ class JITCache:
     """
 
   def __init__(self):
-    self.cache: dict[CompileKeyType, CallableFunction] = {}
+    self.cache: dict[CompileKeyType, JitCompiledFunction] = {}
 
   def __setitem__(self, key: CompileKeyType, fn: JitCompiledFunction) -> None:
     self.cache[key] = fn
 
-  def __getitem__(self, key: CompileKeyType) -> CallableFunction:
+  def __getitem__(self, key: CompileKeyType) -> JitCompiledFunction:
     return self.cache[key]
 
   def __contains__(self, key: CompileKeyType) -> bool:
@@ -176,114 +52,8 @@ class JITCache:
     self.cache.clear()
 
 
-class JITPersistentCache(JITCache):
-  """
-    In-memory cache for compiled functions, which is also backed by persistent storage.
-    Use cutedsl ahead-of-time (AOT) compilation, only supporting enable_tvm_ffi=True
-    """
-
-  EXPORT_FUNCTION_PREFIX = "func"
-  LOCK_TIMEOUT_SECONDS = 15
-
-  def __init__(self, cache_path: Path):
-    super().__init__()
-    cache_path.mkdir(parents=True, exist_ok=True)
-    self.cache_path: Path = cache_path
-
-  def __setitem__(self, key: CompileKeyType, fn: JitCompiledFunction) -> None:
-    JITCache.__setitem__(self, key, fn)
-    self._try_export_to_storage(key, fn)
-
-  def __getitem__(self, key: CompileKeyType) -> CallableFunction:
-    # Use __contains__ to try populating in-memory cache with persistent storage
-    self.__contains__(key)
-    return JITCache.__getitem__(self, key)
-
-  def __contains__(self, key: CompileKeyType) -> bool:
-    # Checks in-memory cache first, then tries loading from storage.
-    # When returning True, guarantees the in-memory cache is populated.
-    if JITCache.__contains__(self, key):
-      return True
-    return self._try_load_from_storage(key)
-
-  def _try_load_from_storage(self, key: CompileKeyType) -> bool:
-    """
-        Try to load a function from persistent storage into in-memory cache.
-        Returns True if loaded successfully, False if not found on disk.
-        Holds a shared lock during loading to prevent concurrent writes.
-        """
-    sha256_hex = self._key_to_hash(key)
-    obj_path = self.cache_path / f"{sha256_hex}.o"
-    with FileLock(
-      self._lock_path(sha256_hex),
-      exclusive=False,
-      timeout=self.LOCK_TIMEOUT_SECONDS,
-      label=sha256_hex,
-    ):
-      if obj_path.exists():
-        fa_log(1, f"Loading compiled function from disk: {obj_path}")
-        m = cute.runtime.load_module(str(obj_path), enable_tvm_ffi=True)
-        fn = getattr(m, self.EXPORT_FUNCTION_PREFIX)
-        JITCache.__setitem__(self, key, fn)
-        return True
-      else:
-        fa_log(1, f"Cache miss on disk for key hash {sha256_hex}")
-    return False
-
-  def _try_export_to_storage(
-    self, key: CompileKeyType, fn: JitCompiledFunction
-  ) -> None:
-    """Export a compiled function to persistent storage under exclusive lock."""
-    sha256_hex = self._key_to_hash(key)
-    with FileLock(
-      self._lock_path(sha256_hex),
-      exclusive=True,
-      timeout=self.LOCK_TIMEOUT_SECONDS,
-      label=sha256_hex,
-    ):
-      obj_path = self.cache_path / f"{sha256_hex}.o"
-      if obj_path.exists():
-        # Another process already exported.
-        fa_log(1, f"Skipping export, already on disk: {obj_path}")
-        return
-      fa_log(1, f"Exporting compiled function to disk: {obj_path}")
-      fn.export_to_c(
-        object_file_path=str(obj_path),
-        function_name=self.EXPORT_FUNCTION_PREFIX,
-      )
-      fa_log(1, f"Successfully exported compiled function to disk: {obj_path}")
-
-  def _key_to_hash(self, key: CompileKeyType) -> str:
-    return hashlib.sha256(pickle.dumps(key)).hexdigest()
-
-  def _lock_path(self, sha256_hex: str) -> Path:
-    return self.cache_path / f"{sha256_hex}.lock"
-
-  def clear(self) -> None:
-    """
-        Not only clear the in-memory cache. Also purge persistent compilation cache.
-        """
-    fa_log(1, f"Clearing persistent cache at {self.cache_path}")
-    super().clear()
-    for child in self.cache_path.iterdir():
-      child.unlink()
-
-
 def get_jit_cache(name: str | None = None) -> JITCache:
-  """
-    JIT cache factory.
-    `name` is an optional identifier to create subdirectories to manage cache.
-
-    When persistent caching is enabled, artifacts are namespaced under a
-    source fingerprint directory so that code or dependency changes
-    automatically invalidate stale entries.
-    """
-  if CUTE_DSL_CACHE_ENABLED:
-    path = get_cache_path() / _compute_source_fingerprint()
-    if name:
-      path = path / name
-    fa_log(1, f"Creating persistent JIT cache at {path}")
-    return JITPersistentCache(path)
-  else:
-    fa_log(1, "Persistent cache disabled, using in-memory JIT cache")
-    return JITCache()
+  """JIT cache factory; ``name`` (a kernel-family tag) is kept for
+  interface stability."""
+  del name
+  return JITCache()

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -1,0 +1,53 @@
+"""Host-only contract tests for the compiled-kernel cache factory."""
+
+import importlib
+import os
+
+import pytest
+
+import ffpa_attn.cute.utils.cache_utils as cache_utils
+
+_ENV_VARS = (
+  "FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED",
+  "FLASH_ATTENTION_CUTE_DSL_CACHE_DIR",
+)
+
+
+@pytest.fixture()
+def fresh_cache_utils():
+  """Reload ``cache_utils`` under a controlled environment; restore after."""
+  saved = {k: os.environ.get(k) for k in _ENV_VARS}
+
+  def _reload(*, enabled, cache_dir=None):
+    os.environ["FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED"] = (
+      "1" if enabled else "0"
+    )
+    if cache_dir is None:
+      os.environ.pop("FLASH_ATTENTION_CUTE_DSL_CACHE_DIR", None)
+    else:
+      os.environ["FLASH_ATTENTION_CUTE_DSL_CACHE_DIR"] = str(cache_dir)
+    return importlib.reload(cache_utils)
+
+  try:
+    yield _reload
+  finally:
+    for key, value in saved.items():
+      if value is None:
+        os.environ.pop(key, None)
+      else:
+        os.environ[key] = value
+    importlib.reload(cache_utils)
+
+
+def test_disabled_flag_is_silent(fresh_cache_utils, recwarn):
+  fresh_cache_utils(enabled=False)
+  assert [w for w in recwarn if issubclass(w.category, UserWarning)] == []
+
+
+def test_enabled_flag_is_an_inert_no_op(fresh_cache_utils, tmp_path):
+  cache_dir = tmp_path / "cache"
+  with pytest.warns(UserWarning, match="is inert"):
+    mod = fresh_cache_utils(enabled=True, cache_dir=cache_dir)
+  cache = mod.get_jit_cache("fwd_sm100")
+  assert type(cache) is mod.JITCache
+  assert not cache_dir.exists()

--- a/tests/test_ffpa_cute_sm100.py
+++ b/tests/test_ffpa_cute_sm100.py
@@ -1112,6 +1112,15 @@ def _varlen_oracle(q, k, v, cu_q, cu_k, causal, num_head):
                  2,
                  2,
                  id="batch70_with_zeros"),
+    # Trailing zero-length segments must reach the kernel unchanged as
+    # zero-work tiles (no host trim; a trim would cost a device→host sync).
+    pytest.param([129, 0], None, 2, 2, id="trailing_zero"),
+    pytest.param([40, 0, 0], [64, 0, 0], 2, 2, id="trailing_zeros_cross"),
+    pytest.param([512, 512, 512, 0, 0, 0, 0, 0],
+                 None,
+                 4,
+                 2,
+                 id="ring_cp_zero_tail"),
   ],
 )
 def test_varlen_matches_per_sequence_oracle(
@@ -1190,8 +1199,10 @@ def test_varlen_zero_legal_key_reads_no_kv(dtype):
   [
     [1024, 320, 2048],  # one long, one non-tile-multiple, one long
     [512, 64, 1536, 200, 1024],  # five sequences, two of them short
+    [1024, 320, 0],  # trailing zero-length sequence reaches the kernel as-is
+    [512, 0, 0, 200, 0, 0],  # zero-work tiles interior and trailing
   ],
-  ids=["v3", "v5"],
+  ids=["v3", "v5", "tail_zero", "zeros_mixed"],
 )
 def test_bwd_varlen_matches_per_sequence_oracle(lens, causal):
   """Packed varlen gradients, per sequence, against an fp32 oracle.
@@ -1208,6 +1219,8 @@ def test_bwd_varlen_matches_per_sequence_oracle(lens, causal):
   scale = 1.0 / math.sqrt(SM100_D512)
 
   for i, ln in enumerate(lens):
+    if ln == 0:
+      continue  # a zero-length sequence owns no rows; nothing to compare
     lo, hi = int(cu[i]), int(cu[i + 1])
     refs = _ref_bwd(
       q[lo:hi].detach().unsqueeze(0),

--- a/tests/test_ffpa_cute_sm100.py
+++ b/tests/test_ffpa_cute_sm100.py
@@ -55,7 +55,6 @@ from ffpa_attn.cute._fwd_d512_sm100 import (
   FFPAAttnFwdSm100D512,
   compile_key_fields,
 )
-from ffpa_attn.cute.utils import AuxData
 from ffpa_attn.cute.utils.cute_dsl_utils import to_cute_tensor
 from ffpa_attn.cute.utils.hd512_helpers import check_tmem_intervals
 from ffpa_attn.cute.utils.named_barrier import NamedBarrierFwdSm100Hd512
@@ -654,7 +653,7 @@ _FORWARD_UNSUPPORTED_ARGS = (
   None,  # learnable_sink
   None,  # descale_tensors
   None,  # blocksparse_tensors
-  AuxData(),
+  None,  # aux_data
 )
 
 


### PR DESCRIPTION
## Summary

Fix two CuTeDSL issues affecting varlen execution and compiled-kernel caching:

* Remove per-call device-to-host synchronization from varlen forward/backward. Zero-length segments now reach the kernels unchanged as zero-work tiles, while exact `cu_seqlens` guards use `torch._assert_async`.
* Retire the broken cross-process persistent cache and keep only in-process `JitCompiledFunction` wrappers. The legacy cache flag is inert and warns when set.
* SM100 D512 also passes `aux_data=None`, eliminating the unsupported `JitArgument` warning.

## Motivation

The old persistent cache reloaded `export_to_c` host-entry callables with a fixed ABI into call sites expecting the dynamic wrapper ABI. A warm cache directory could therefore fail with:

```text
TypeError: Expects 17 parameters
```

Varlen validation and trailing-zero trimming also used `.item()` on CUDA tensors on every call, forcing device-to-host synchronization and preventing CUDA graph capture.

Cross-process persistence is intentionally unavailable after this change; each process compiles each specialization once.

## Testing

Validated on **B200** with:

* [x] Dense and packed-varlen D512 forward
* [x] Trailing/interior zero-length segments in forward and backward
* [x] Two successive processes using one shared cache directory
* [x] No 17-slot ABI error, no `AuxData` warning, and no cache artifacts
