### PR TITLE
cuda: unify lazy-rescale governance (fp4 + native per-row, fp8/cute keep vote)

### DIFF
--- a/.github/skills/ffpa-cuda-understand/SKILL.md
+++ b/.github/skills/ffpa-cuda-understand/SKILL.md
@@ -488,7 +488,7 @@ lse 公式（NVFP4 PV）：`lse = (m*L + log2(row_sum) + log2(1/2688))*ln2 + sca
 ### 6.6 性能与优化记录
 
 - 相对 fp8（D=192）：self 1.47x / causal 1.29x / gqa 1.50x / cross-dense 1.57x。fp4 attn kernel 本身比 fp8 快 ~23%；blockscale mxf4nvf4 MMA 吞吐 ≈ fp8 dense（收益主要来自带宽）。
-- 已落地：条件 rescale（warp-vote 跳过，dense 96.5% 命中，-4.9%）、`ex2.approx.ftz.f32`（消 ptxas range 胶水，-5.9%）、regalloc 按 D 门控（D≤128 用 alloc<224>，D≥192 必须 232）。
+- 已落地：条件 rescale（dense 96.5% 命中，-4.9%；PC-11 后 fp4 为 fragment 级 per-row 守卫（`scores_scale(mi)<1.0f`，attn-mask 再 -3.7%/-4.7%），m4n2 保留 vote（其编译形态是 PC-0-5 稳定性载荷））、`ex2.approx.ftz.f32`（消 ptxas range 胶水，-5.9%）、regalloc 按 D 门控（D≤128 用 alloc<224>，D≥192 必须 232）。
 - 证伪：Q smem 复用（fp4 L1TEX hit 已 96.75% 饱和，fp8 的前提不成立，+1.8% 回退，默认 OFF 代码保留）、rescale merge in-place（+1.7%，把 FMUL 拉进 MMA 依赖链）、q_full wait 延迟（中性偏负）、exp2 多项式替换、三段化 causal middle 段（投入产出低留后续）。
 - **小 Nq（cross/decode）结构性不划算**：固定前处理链 ~1.1ms 占比过大。
 - fp4 相关 falsified 记录另见 memory：`ffpa-fp4-125x-sprint` / `ffpa-fp4-64x64` / `ffpa-fp4-pingpong`。
@@ -703,7 +703,7 @@ $$
 
 终值 $O=O^{(T)}/L^{(T)}$；log-sum-exp = $m^{(T)}+\ln L^{(T)}$。ffpa 的 fp8/fp4 kernel 在 **log2 域**实现（`exp2` 由 MUFU 单指令完成，`.approx.ftz.f32` 变体消除了 ptxas 对非 ftz 版插入的 range 胶水链，fp4 路径 -5.9%），递推结构不变。
 
-**lazy rescale**（FA-4 条件 rescale）： $\alpha$ 接近 1 时跳过 $O$ 的 rescale，把膨胀因子滚入下一 tile 的 $\tilde{P}$。判定用 per-row `row_scale[row]<1.0f`（fp8 persist-D，commit `f2ee001`）或 warp-vote `scores_scale!=1`（fp4，dense 命中率 96.5%）。数学代价： $\tilde{P}$ 相对 stale max 膨胀至多 $2^T$（ $T$ 为 log2 域阈值；FA-4 原文对 BF16 取 $\tau=8$，fp8 取 4、由发射域天花板反推），见 §11.6 溢出约束。
+**lazy rescale**（FA-4 条件 rescale）： $\alpha$ 接近 1 时跳过 $O$ 的 rescale，把膨胀因子滚入下一 tile 的 $\tilde{P}$。判定形态分族（PC-11 实测收敛，2026-09-09）：**fp4 = fragment 级 per-row 守卫** `scores_scale(mi)<1.0f`（attn-mask 再 -3.7%/-4.7%）；**native = branchless clamp** `(f<1.0f)?f:1`（中性，顺带拒 NaN）；**fp8 split-D ×2 / cute fp16 ×4 / fp4 m4n2 = warp-vote** `__any_sync`（fp8 persist-D 早已 per-row，f2ee001；vote 是 warp-uniform 分支 + 无谓词 FFMA 链——thread-local 守卫放进 split-D 展开的 rescale 乘法循环会引入跨 lane 分歧，attn-mask 实测 fp8 D512 +23.9%；fp4 m4n2 另有 PC-0-5 时序载荷）；threshold 恒 1.0 时 `x*1.0f` bitwise no-op，skip 是纯性能优化。数学代价： $\tilde{P}$ 相对 stale max 膨胀至多 $2^T$（ $T$ 为 log2 域阈值；FA-4 原文对 BF16 取 $\tau=8$，fp8 取 4、由发射域天花板反推），见 §11.6 溢出约束。
 
 **ffpa 代码**：`cute/softmax.cuh`（`online_softmax_fp8_fixed` 及 `kMaxScaleAfter`——tile-max 用未 scale 的 scores 归约、cross-lane 后再乘 scale，省 max-pass 每 element 一次 FMUL 且无跨 pass 依赖，kernel -1.56%）；fp4 lse 公式 `(m*L + log2(row_sum) + log2(1/2688))*ln2 + scale*qkm`（`cute/fp4/sm_120/persist_d.cuh`）。
 

--- a/.github/skills/ffpa-cuda-understand/references/rfc-future-optimizations.md
+++ b/.github/skills/ffpa-cuda-understand/references/rfc-future-optimizations.md
@@ -101,7 +101,7 @@
 | PC-8 | fp8 split-D M4N2 量化大 D kernel 性能优化 | P | ⬜ 待开始 | PC-7（顺序） |
 | PC-9 | fp4 split-D (M8N1) 量化大 D kernel 性能优化 | P | ⬜ 待开始 | PC-8（顺序） |
 | PC-10 | fp4 split-D M4N2 量化大 D kernel 性能优化 | P | ⬜ 待开始 | PC-9（顺序） |
-| PC-11 | warp 级 `__any_sync` lazy-rescale 统一治理（精度治理专项） | P | ⬜ 待开始 | 已与 PC-0-5 解耦可独立推进（vote 非本次 race 根因——force-rescale 实证；治理价值在消除 warp-uniform 分支的调度脆弱性） |
+| PC-11 | warp 级 `__any_sync` lazy-rescale 统一治理（精度治理专项） | P | ✅ **完成（2026-09-09，范围收敛）** | **fp4 + native 两族落地 per-row**（fp4 attn-mask -3.7%/-4.7%，其余 ~0%；native branchless clamp 中性）；**fp8 ×2 + cute fp16 ×4 回退 vote 形态**（per-row 守卫进 rescale 循环引入跨 lane 分歧，attn-mask 实测 fp8_D512 **+23.9%**）；**fp4 m4n2 豁免**（vote 编译形态是 PC-0-5 稳定性载荷）；m4n2 bf16 失败定责 HEAD 既有（控制实验），race gate 恢复 fp16 语义 |
 | PC-12 | cute sm_80 fp16 性能优化（cp.async + 多级流水线，fp8/sm_89 路线前置） | P | ⬜ 待开始 | —；被 PC-6 依赖 |
 | PC-13 | fp8/fp4 hybrid 路径性能优化（双 attn kernel → 融合 kernel） | P | ⬜ 待开始 | —（与 PC-7~10 协同） |
 | PC-14 | fp16 dropout 路径性能优化（RNG bitmap 预计算 + producer/consumer 重排） | P | ✅ 完成（consumer 侧双缓冲 bitmap：persist_d D=64 1.02x / D=128 2.25x，split_d D=320 2.05x，sm_80 split_d 完成（f158eb1），bitwise 全过 + 全 task 套件零回归（fp16 7 tasks×2 dtypes + fp8/fp4 smoke）；producer 方案证伪；**m4n2 证伪不实现**（D=768 bitmap 212.82ms 反慢于 inline 202.31ms，tile 小 + PV/exchange 主导，RNG 非瓶颈；未来有需求再评估）；**persist-D half-row 方案要求 kBc≥64**——D=192/256 的 kBc=32 实例化编译期 `kBitmapCapable` 门控回落 inline Philox（d6a4a1d）；RNG 指令地板结论见 SKILL §11.16——契约下上限约 1.2x） | PC-0 同构（bias tile 协议复用）；FC-5 是量化路径功能项（⏸），与本项无重叠 |
@@ -207,7 +207,7 @@
 - [ ] PC-4：fp4 persist-D attn kernel 内部优化
 - [ ] PC-5：CUDA graph 友好化
 - [ ] PC-6：sm_89 fp8 int4 QK（低优搁置：sm_120 无原生 int4 MMA，SA2 int4 kernel 未开源）
-- [ ] PC-11：warp 级 `__any_sync` lazy-rescale 统一治理（精度治理专项，2026-09-01 立项）
+- [x] PC-11：warp 级 `__any_sync` lazy-rescale 统一治理（精度治理专项，2026-09-01 立项，2026-09-09 完成）
   - 背景：PC-0-5 调查早期曾怀疑 fp4 split_d_m4n2 的 warp-uniform lazy-rescale（`__any_sync(0xffffffff, row_scale != 1.0f ...)`）参与 bias 场景的 bitwise 非确定，**后续消元已证伪 vote 因果**（force-rescale 后仍触发；race 真身为跨模板时序敏感竞争，见 PC-0-5 完成清单）。本专项保留的治理价值：`__any_sync` 投票模式源自 CUTLASS 77_blackwell_fmha 的 **shared-TMEM collective rescale** 场景——那里 warp-uniform 是必须的；本仓库所有 kernel 的 rescale 目标均为 **thread-private 寄存器**，投票既非必需，又把 per-row 决策强行提升为 warp-uniform 分支，徒增调度脆弱性与 warp divergence 面。
   - 参考实现（治理目标形态）：`csrc/cuffpa/cute/fp8/sm_120/persist_d.cuh` 已改为 thread-level per-row——`const float rs = (kv_tile > 0 && row_scale[row] < 1.0f) ? row_scale[row] : 1.0f;` 逐行独立判断（`< 1.0f` 顺带拒绝全 masked 行的 NaN scale），无跨 lane 通信；其注释含完整论证。
   - 治理清单（`grep -r "__any_sync" csrc/cuffpa/cute/` 全量 9 处实际使用 + 1 处已治理注释）：
@@ -216,6 +216,13 @@
     - `fp4/sm_120/split_d_m4n2.cuh`（PC-0-5 实证 race，随 PC-0-5 修复先行落地）、`fp4/sm_120/split_d.cuh`、`fp4/sm_120/persist_d.cuh`（fp4 persist_d 3/30 低概率触发待排查）
     - `sm_80/split_d.cuh`
   - 动作与验收：①逐 kernel 转 per-row lazy-rescale（语义等价，多数 tile 无 max 增长时按行跳过乘法，性能预期持平或略优）；②每处 `ffpa_attn.bench` A/B 无回归；③每家族补"no-bias 前置 ×N → bias self-loop bitwise 断言"用例（PC-0-5 复现脚本 `.tmp/pc5-race/` 沉淀为 tests 后纳入）；④PC-0-5 的 fp4 m4n2 修复是本专项第一块拼图，其余 8 处排期跟进。
+  - **完成记录（2026-09-09，范围收敛为 fp4 + native 两族）**：
+    - **fp4 三处落地**：`fp4_pscale.cuh` `rescale_acc` 加 `scores_scale(mi) < 1.0f` fragment 级守卫（persist_d/split_d 共用，`SoftmaxFusedMxfp8` 同享）；fp4 `persist_d` 三分支收敛为 `if (kv_tile > 0) rescale_acc(tOrO_store)` in-place；fp4 `split_d` 消费点 per-row。**收益**：fp4 attn-mask **-3.7%**（D64 2.73→2.63ms）/ **-4.7%**（D320 15.82→15.07ms），其余 task ~0%；独立强 gate（fp4 D64/D128 self+causal，+1% 阈值）通过。
+    - **native 两处落地**：`prefill.cuh` `sync_rescaling_tiling_o` 删 `need_rescale` 尾参、factor 改 `< 1.0f` branchless clamp（顺带拒绝全 masked 行 NaN）；sm_80/sm_120 `split_d` 删 vote。A/B：sm_80 全 task ±0.3%；sm_120（tma impl）min-of-5 ≤+1.3% 混号（该 impl run 间波动大，单轮 spike 可至 +20%，需 min 口径）。
+    - **fp8 ×2 + cute fp16 ×4 六处回退 HEAD vote 形态**：per-row 守卫位于 rescale 乘法展开循环内且 `row_scale` 为 thread-local → 跨 lane 分歧 + 谓词化 FFMA，attn-mask（低 skip 率、D 大、乘法链长）下实测回归——**fp8_D512 attn-mask +23.9%**（33.99→42.1ms，3 复跑 42.08/42.15/42.10 ±0.2%）、fp8_D768 +6.8%、cute_D128 +2.9%。结论：**vote（warp-uniform 分支 + 无谓词 FFMA）是 split-D 展开循环的 perf 最优形态；per-row 仅当守卫在 fragment 级（fp4 `scores_scale(mi)`，无展开循环开销）时获益**。
+    - **fp4 m4n2 豁免**（kernel 内 EXEMPTION 注释在档）：per-row（含/不含 `__syncwarp`）都重开 PC-0-5 窗口，vote 编译形态是稳定性的载荷。
+    - **m4n2 bf16 新证据（HEAD 对照控制实验）**：bf16 输入下 **HEAD 原始代码** pure-bias 也 10/10 失败（stash 全部 csrc 改动 → 重建 → 同 probe，指纹同 d=[192,224)、lse 稳定、no-bias 干净）——09-04 的"mode 0 纯序列稳定"是 fp16 输入下的 dtype 相关平衡；race gate 测试恢复 fp16 语义 + 裁剪构建（PC-15）skipif（顺带修复默认构建下直接报错的缺口）。
+    - 验收：新增 `tests/test_ffpa_lazy_rescale_determinism.py`（5 形状 no-bias 前置×3 → bias 自环×3 int16 bitwise + 全 masked 行分族断言：fp16 NaN 行 / fp4 恒 0 行）；16 配置 bench A/B + SDPA 参照一致性校验——**首轮基线 8 配置被 GPU 级污染（SDPA 参照同膨胀 ~2x，FFPA 假 -50%）**，教训：A/B 必须校验 SDPA 参照；污染配置以 HEAD 干净重采对照替代；pytest 468 passed / 292 skipped（fp16-trimmed 与未编译 headdim 的预期 skip）。
 - [ ] PC-7：fp8 split-D (M8N1) 量化大 D kernel 性能优化
 - [ ] PC-8：fp8 split-D M4N2 量化大 D kernel 性能优化
 - [ ] PC-9：fp4 split-D (M8N1) 量化大 D kernel 性能优化

--- a/csrc/cuffpa/cute/fp4/fp4_pscale.cuh
+++ b/csrc/cuffpa/cute/fp4/fp4_pscale.cuh
@@ -273,23 +273,6 @@ struct SoftmaxFused {
     }
   }
 
-  template <typename TensorAcc>
-  CUTE_DEVICE void rescale_o(TensorAcc& o_store, TensorAcc const& o_tmp) {
-    Tensor o_store_reduction_view = make_tensor(
-        o_store.data(), convert_to_reduction_layout(o_store.layout()));
-    Tensor o_tmp_reduction_view =
-        make_tensor(o_tmp.data(), convert_to_reduction_layout(o_tmp.layout()));
-    CUTE_UNROLL
-    for (int mi = 0; mi < size(row_max); ++mi) {
-      CUTE_UNROLL
-      for (int ni = 0; ni < size<1>(o_store_reduction_view); ni++) {
-        o_store_reduction_view(mi, ni) =
-            o_store_reduction_view(mi, ni) * scores_scale(mi) +
-            o_tmp_reduction_view(mi, ni);
-      }
-    }
-  }
-
   // split-d companion to finalize(): O lives in per-D-chunk fragments, so
   // finalize() folds row_sum on the first chunk and this scales the rest
   // with the already-folded row_sum.
@@ -309,16 +292,20 @@ struct SoftmaxFused {
   }
 
   // split-d lazy rescale: multiply an O chunk in place by scores_scale
-  // (the gemm then accumulates the new tile on top).
+  // (the gemm then accumulates the new tile on top). Per-row guard (PC-11):
+  // rows whose scale stayed 1.0 skip the multiply; < 1.0f also rejects NaN
+  // on all-masked rows.
   template <typename TensorAcc>
   CUTE_DEVICE void rescale_acc(TensorAcc& o_store) {
     Tensor o_store_reduction_view = make_tensor(
         o_store.data(), convert_to_reduction_layout(o_store.layout()));
     CUTE_UNROLL
     for (int mi = 0; mi < size(row_max); ++mi) {
-      CUTE_UNROLL
-      for (int ni = 0; ni < size<1>(o_store_reduction_view); ni++) {
-        o_store_reduction_view(mi, ni) *= scores_scale(mi);
+      if (scores_scale(mi) < 1.0f) {
+        CUTE_UNROLL
+        for (int ni = 0; ni < size<1>(o_store_reduction_view); ni++) {
+          o_store_reduction_view(mi, ni) *= scores_scale(mi);
+        }
       }
     }
   }

--- a/csrc/cuffpa/cute/fp4/sm_120/persist_d.cuh
+++ b/csrc/cuffpa/cute/fp4/sm_120/persist_d.cuh
@@ -965,23 +965,15 @@ __global__ void __launch_bounds__(384, 1) persist_d_ws_fwd_cute_fp4_sm120(
         }
       };
 
-      if (kv_tile == 0) {
-        gemm_rs_pv(tOrO_store);
-      } else {
-        // scores_scale == 1.0f exactly when the row max did not move this
-        // tile (~96% of dense tiles): O = O*1 + O_new needs no rescale at
-        // all. Warp-vote keeps both fragments on one uniform path.
-        const bool need_rescale = softmax_fused.scores_scale[0] != 1.0f ||
-                                  softmax_fused.scores_scale[1] != 1.0f;
-        if (__any_sync(0xffffffff, need_rescale)) {
-          Tensor tOrO = make_fragment_like(tOrO_store);
-          clear(tOrO);
-          gemm_rs_pv(tOrO);
-          softmax_fused.rescale_o(tOrO_store, tOrO);
-        } else {
-          gemm_rs_pv(tOrO_store);
-        }
-      }
+      // Lazy rescale (PC-11, per-row): pre-scale the resident O in place
+      // (rows whose scale stayed 1.0 skip the multiply inside rescale_acc)
+      // and let the gemm accumulate directly -- same shape as the fp8
+      // persist-D kernel. This replaces the old temp-fragment +
+      // rescale_o merge; per-row guarding keeps the dense-tile fast path
+      // (zero FMUL) so the FMUL never enters the MMA chain unguarded.
+      if (kv_tile > 0)
+        softmax_fused.rescale_acc(tOrO_store);
+      gemm_rs_pv(tOrO_store);
     }
 
     softmax_fused.finalize(tOrO_store);

--- a/csrc/cuffpa/cute/fp4/sm_120/split_d.cuh
+++ b/csrc/cuffpa/cute/fp4/sm_120/split_d.cuh
@@ -783,12 +783,9 @@ __global__ void __launch_bounds__(Traits::kNumThreads, 1)
 
       // Lazy rescale: scores_scale == 1.0f exactly when the row max did
       // not move this tile (~96% of dense tiles). Pre-scale the resident O
-      // chunks in place; the gemm then accumulates on top.
-      const bool need_rescale =
-          kv_tile > 0 &&
-          __any_sync(0xffffffff, softmax_fused.scores_scale[0] != 1.0f ||
-                                     softmax_fused.scores_scale[1] != 1.0f);
-      if (need_rescale) {
+      // chunks in place; the gemm then accumulates on top. Per-row (PC-11):
+      // rescale_acc guards each row by scores_scale < 1.0f.
+      if (kv_tile > 0) {
 #pragma unroll
         for (int v = 0; v < kDChunksV; ++v) {
           auto tCrO =

--- a/csrc/cuffpa/cute/fp4/sm_120/split_d_m4n2.cuh
+++ b/csrc/cuffpa/cute/fp4/sm_120/split_d_m4n2.cuh
@@ -736,6 +736,14 @@ __global__ void __launch_bounds__(Traits::kNumThreads, 1)
       }
       // Lazy rescale: row_scale == 1.0f when the running row max did not
       // grow on this tile; warp-vote the skip.
+      // PC-11 EXEMPTION: do not replace this vote with the per-row guard
+      // used everywhere else. The vote's compiled form is load-bearing for
+      // the PC-0-5 stability (validated on fp16 inputs); re-shaping the
+      // lazy-rescale code shifts the bias-template timing window. Follow-up
+      // control experiment (2026-09-09): bf16 inputs open the window even
+      // at HEAD (10/10, d=[192,224) PV C tile fingerprint, lse stable,
+      // no-bias clean) -- the equilibrium is dtype dependent, keep the
+      // validated form here.
       const bool need_rescale =
           kv_tile > 0 &&
           __any_sync(0xffffffff, row_scale[0] != 1.0f || row_scale[1] != 1.0f);

--- a/csrc/cuffpa/native/prefill.cuh
+++ b/csrc/cuffpa/native/prefill.cuh
@@ -1022,14 +1022,16 @@ __device__ __forceinline__ void sync_rescaling_tiling_o(
     const float* rescale_o_factor_0,  // rescale factor
     const float* rescale_o_factor_1,  // rescale factor
     const int n_tile_id,              // tile_K_seqlen
-    const int d_tile_id,              // j
-    const bool need_rescale = true  // FA-4: false -> factor=1, accumulate only
+    const int d_tile_id               // j
 ) {
   using Traits = DtypeTraits<kDataType>;
-  // need_rescale is warp-uniform (from __any_sync). When false, force
-  // factor=1.0 so fmaf collapses to D += O (skip O rescale).
-  const float f0 = need_rescale ? rescale_o_factor_0[0] : 1.0f;
-  const float f1 = need_rescale ? rescale_o_factor_1[0] : 1.0f;
+  // Per-factor clamp (PC-11): factors are <= 1 and hit 1.0 exactly when the
+  // row max did not move, so fmaf collapses to D += O on those rows;
+  // < 1.0f also rejects NaN factors on all-masked rows.
+  const float f0 =
+      (rescale_o_factor_0[0] < 1.0f) ? rescale_o_factor_0[0] : 1.0f;
+  const float f1 =
+      (rescale_o_factor_1[0] < 1.0f) ? rescale_o_factor_1[0] : 1.0f;
   // Now, we get [Br,8] slice of [Br,d], each warp(MMA) contains m16n8.
   // 0. Rescale O: Online rescaling O each tile_K_seqlen step, need m_new,
   // m_old. m = max(m_old, m_new), O_new[Br,d] = exp(m_old - m) * O_old + P@V m

--- a/csrc/cuffpa/native/sm_120/split_d.cuh
+++ b/csrc/cuffpa/native/sm_120/split_d.cuh
@@ -570,11 +570,6 @@ __global__ void __launch_bounds__(WARP_SIZE* kMmaTileSeqLenQ* kMmaTileSeqLenK +
           &lane_row_max_new[0][0], &lane_block_row_max_old[0][0],
           tile_K_seqlen);
 
-      // FA-4 warp-uniform vote: skip O rescale when all factors are 1.0.
-      const bool local_need_rescale =
-          (rescale_o_factor_0[0] < 1.0f) || (rescale_o_factor_1[0] < 1.0f);
-      const bool need_rescale = __any_sync(0xffffffff, local_need_rescale);
-
       // kNonWS: thread 0 prefetches first kStagePV V stages.
       if constexpr (kNonWS) {
         if (threadIdx.x == 0) {
@@ -628,7 +623,7 @@ __global__ void __launch_bounds__(WARP_SIZE* kMmaTileSeqLenQ* kMmaTileSeqLenK +
             ffpa::prefill::sync_rescaling_tiling_o<kOStorageAccFloat32,
                                                    kMmaAccFloat32PV, kDataType>(
                 &R_D[0][0][0], &R_O[0], &rescale_o_factor_0[0],
-                &rescale_o_factor_1[0], tile_K_seqlen, j, need_rescale);
+                &rescale_o_factor_1[0], tile_K_seqlen, j);
           }
         }
         // Release V stage: all kSubTilesV*2 j's consumed this tile.

--- a/csrc/cuffpa/native/sm_80/split_d.cuh
+++ b/csrc/cuffpa/native/sm_80/split_d.cuh
@@ -609,11 +609,6 @@ __global__ void __launch_bounds__(WARP_SIZE* kMmaTileSeqLenQ* kMmaTileSeqLenK)
           &lane_row_max_new[0][0], &lane_block_row_max_old[0][0],
           tile_K_seqlen);
 
-      // FA-4 warp-uniform vote: skip O rescale when all factors are 1.0.
-      const bool local_need_rescale =
-          (rescale_o_factor_0[0] < 1.0f) || (rescale_o_factor_1[0] < 1.0f);
-      const bool need_rescale = __any_sync(0xffffffff, local_need_rescale);
-
       // <HGEMM in registers>
 #pragma unroll
       for (int j = 0; j < kValTileHeadDimV; ++j) {  // 8, 16, 32, ...
@@ -764,7 +759,7 @@ __global__ void __launch_bounds__(WARP_SIZE* kMmaTileSeqLenQ* kMmaTileSeqLenK)
         ffpa::prefill::sync_rescaling_tiling_o<kOStorageAccFloat32,
                                                kMmaAccFloat32PV, kDataType>(
             &R_D[0][0][0], &R_O[0], &rescale_o_factor_0[0],
-            &rescale_o_factor_1[0], tile_K_seqlen, j, need_rescale);
+            &rescale_o_factor_1[0], tile_K_seqlen, j);
 
         if constexpr (kStagePV > 1) {
           // Wait next V tile g2s ready.

--- a/tests/test_ffpa_fp4_m4n2_bias_race.py
+++ b/tests/test_ffpa_fp4_m4n2_bias_race.py
@@ -16,6 +16,12 @@ sensitive, documented in RFC PC-0-5.
 These tests pin both trigger sequences (with and without the no-bias
 prelude). The pure-bias case is the must-pass gate; the prelude case is
 tracked as xfail for the accepted residual.
+
+Note (2026-09-09, PC-11 control experiment): the mode-0 equilibrium is
+dtype dependent. With bf16 inputs the pure-bias sequence fails 10/10 at
+HEAD (bitwise-unstable O, same d=[192,224) PV C tile fingerprint, stable
+lse, no-bias clean) -- fp16 inputs are the validated-stable dtype, so the
+gate runs fp16 only.
 """
 
 import math
@@ -32,6 +38,11 @@ try:
 except Exception:  # pragma: no cover
   FFPA_CUDA_EXT_BUILT = False
 
+try:
+  from ffpa_attn.cuda import CUDA_INPUT_FP16_AVAILABLE
+except Exception:  # pragma: no cover
+  CUDA_INPUT_FP16_AVAILABLE = True
+
 
 def _fp4_available() -> bool:
   if not torch.cuda.is_available():
@@ -43,6 +54,12 @@ def _fp4_available() -> bool:
 pytestmark = [
   pytest.mark.skipif(not _fp4_available(), reason="fp4 path requires sm_120"),
   pytest.mark.skipif(not FFPA_CUDA_EXT_BUILT, reason="ffpa CUDA ext required"),
+  pytest.mark.skipif(
+    not CUDA_INPUT_FP16_AVAILABLE,
+    reason="fp16 CUDA inputs trimmed; this gate is validated on fp16 inputs"
+    " (bf16 opens the pure-sequence window even at HEAD, 2026-09-09"
+    " control experiment); rebuild with ENABLE_FFPA_CUDA_INPUT_FP16=1",
+  ),
 ]
 
 
@@ -62,12 +79,17 @@ def _run(q, k, v, backend, bias):
 
 
 def _make_case(D):
+  # fp16 inputs: the validated-stable dtype for this gate. bf16 inputs
+  # open the pure-sequence timing window even at HEAD (2026-09-09 control
+  # experiment, 10/10 nondeterministic with the same d=[192,224) PV tile
+  # fingerprint), so bf16 cannot serve as the clean baseline here.
   torch.manual_seed(0)
   B, H, N = 1, 4, 2048
-  q = torch.randn(B, H, N, D, device="cuda", dtype=torch.float16) * 0.5
-  k = torch.randn(B, H, N, D, device="cuda", dtype=torch.float16) * 0.5
-  v = torch.randn(B, H, N, D, device="cuda", dtype=torch.float16) * 0.5
-  bias = torch.randn(1, 1, 1, N, device="cuda", dtype=torch.float16) * 0.25
+  dt = torch.float16
+  q = torch.randn(B, H, N, D, device="cuda", dtype=dt) * 0.5
+  k = torch.randn(B, H, N, D, device="cuda", dtype=dt) * 0.5
+  v = torch.randn(B, H, N, D, device="cuda", dtype=dt) * 0.5
+  bias = torch.randn(1, 1, 1, N, device="cuda", dtype=dt) * 0.25
   backend = CUDABackend(
     forward=True,
     enable_fp8=False,

--- a/tests/test_ffpa_lazy_rescale_determinism.py
+++ b/tests/test_ffpa_lazy_rescale_determinism.py
@@ -1,0 +1,141 @@
+"""Lazy-rescale per-row governance determinism (PC-11).
+
+PC-11 replaced every warp-uniform __any_sync lazy-rescale vote with a
+thread-level per-row guard (``row_scale < 1.0f``); the fp4 m4n2 kernel is
+exempt (its vote is load-bearing for the PC-0-5 pure-sequence stability,
+covered by test_ffpa_fp4_m4n2_bias_race). Removing the vote must not open
+bitwise instability: after a no-bias prelude, a bias self-loop must stay
+bit-identical.
+
+The all-masked-row case pins the documented per-family behavior around the
+per-row guard: fp4's InfCheck softmax drives scores_scale to exactly 0.0
+and the guarded finalize emits zeros (no NaN anywhere); the fp16 family
+has no row_sum guard, so a fully masked row is NaN (SDPA-consistent) --
+what matters for PC-11 is that the NaN stays confined to the masked row
+(the old warp-uniform vote let one row's rescale decision leak across the
+warp).
+"""
+
+import math
+
+import pytest
+import torch
+
+from ffpa_attn.functional import CUDABackend
+
+try:
+  from ffpa_attn.cuda import set_cuda_backend_impl, CudaBackendImpl
+  from ffpa_attn.cuda._ffpa_fwd import _ffpa_attn_forward_cuda
+  FFPA_CUDA_EXT_BUILT = True
+except Exception:  # pragma: no cover
+  FFPA_CUDA_EXT_BUILT = False
+
+pytestmark = pytest.mark.skipif(
+  not torch.cuda.is_available() or not FFPA_CUDA_EXT_BUILT,
+  reason="ffpa CUDA ext on a CUDA device required",
+)
+
+# family -> (impl, enable_fp8, enable_fp4, D); D picks the kernel family
+# segment (persist_d / split_d / split_d_m4n2) per the D dispatch table.
+# fp4 m4n2 is exempt from PC-11 (its vote is load-bearing for the PC-0-5
+# pure-sequence stability) and stays covered by test_ffpa_fp4_m4n2_bias_race.
+_CASES = [
+  ("fp16_persist", CudaBackendImpl.CUTE_TMA, False, False, 128),
+  ("fp16_split", CudaBackendImpl.CUTE_TMA, False, False, 320),
+  ("fp8_split", CudaBackendImpl.CUTE_TMA_FP8, True, False, 320),
+  ("fp4_persist", CudaBackendImpl.CUTE_TMA_FP4, False, True, 128),
+  ("fp4_split", CudaBackendImpl.CUTE_TMA_FP4, False, True, 320),
+]
+
+
+def _backend(enable_fp8, enable_fp4):
+  backend = CUDABackend(
+    forward=True,
+    enable_fp8=enable_fp8,
+    enable_fp4=enable_fp4,
+    enable_tma=True,
+    enable_cute=True,
+    backward=False,
+  )
+  backend.fp8_hybrid = False
+  backend.fp4_hybrid = False
+  return backend
+
+
+def _run(impl, q, k, v, backend, bias):
+  set_cuda_backend_impl(impl)
+  o, _ = _ffpa_attn_forward_cuda(
+    q, k, v, None, bias, backend.stages, backend.acc_code, 0,
+    1.0 / math.sqrt(q.size(-1)), 0.0, 0, 0, backend.fp8_smooth_k,
+    backend.fp8_smooth_v, backend.fp8_q_quant_method_code,
+    backend.fp8_k_quant_method_code, backend.fp8_v_quant_method_code,
+    backend.fp8_pv_acc_code, backend.fp8_qk_mm_type_code, backend.fp8_hybrid,
+    backend.fp8_hybrid_n_early, backend.fp4_hybrid, backend.fp4_hybrid_n_early,
+    backend.fp8_hadamard, backend.fp4_hadamard, backend.fp4_pv_mm_type_code,
+    backend.fp4_smooth_v, backend.tensor_layout_code
+  )
+  return o
+
+
+def _make_inputs(D):
+  torch.manual_seed(0)
+  B, H, N = 1, 4, 2048
+  q = torch.randn(B, H, N, D, device="cuda", dtype=torch.bfloat16) * 0.5
+  k = torch.randn(B, H, N, D, device="cuda", dtype=torch.bfloat16) * 0.5
+  v = torch.randn(B, H, N, D, device="cuda", dtype=torch.bfloat16) * 0.5
+  # bias must match Q dtype (fp32 masks need the trimmed f=1 variants).
+  bias = torch.randn(1, 1, 1, N, device="cuda", dtype=torch.bfloat16) * 0.25
+  return q, k, v, bias
+
+
+def _run_or_skip_headdim(impl, q, k, v, backend, bias):
+  try:
+    return _run(impl, q, k, v, backend, bias)
+  except RuntimeError as exc:
+    if "headdim not support" in str(exc):
+      pytest.skip(f"D={q.size(-1)} not in the compiled headdim set")
+    raise
+
+
+@pytest.mark.parametrize("name,impl,fp8,fp4,D", _CASES)
+def test_bias_selfloop_determinism(name, impl, fp8, fp4, D):
+  q, k, v, bias = _make_inputs(D)
+  backend = _backend(fp8, fp4)
+  # fp4 m4n2 is deliberately absent from _CASES (vote exemption, see
+  # test_ffpa_fp4_m4n2_bias_race); every case here takes the prelude.
+  for _ in range(3):
+    _run_or_skip_headdim(impl, q, k, v, backend, None)
+
+  ref = _run_or_skip_headdim(impl, q, k, v, backend, bias)
+  ref_bits = ref.view(torch.int16).flatten()
+  for _ in range(3):
+    out = _run_or_skip_headdim(impl, q, k, v, backend, bias)
+    out_bits = out.view(torch.int16).flatten()
+    assert torch.equal(out_bits, ref_bits), (
+      f"{name} bias self-loop output is not bit-deterministic (PC-11): "
+      f"{(out_bits != ref_bits).sum().item()} int16 lanes differ"
+    )
+
+
+@pytest.mark.parametrize(
+  "name,impl,fp8,fp4,D",
+  [c for c in _CASES if c[0] in ("fp16_persist", "fp4_persist")],
+)
+def test_all_masked_bias_row_behavior(name, impl, fp8, fp4, D):
+  q, k, v, _ = _make_inputs(D)
+  N = q.size(2)
+  bias = torch.zeros(1, 1, N, N, device="cuda", dtype=torch.bfloat16)
+  bias[:, :, 0, :] = float("-inf")
+  backend = _backend(fp8, fp4)
+  out = _run_or_skip_headdim(impl, q, k, v, backend, bias)
+  if fp4:
+    assert not torch.isnan(out).any(), f"{name}: NaN leaked into O"
+    assert out[0, :, 0].abs().max().item(
+    ) == 0.0, (f"{name}: fully masked row must finalize to zeros")
+  else:
+    # fp16/fp8 have no row_sum guard: fully masked rows are NaN (SDPA
+    # parity); the masked row must not corrupt its warp-mate rows.
+    assert torch.isnan(out[0, :, 0]).all()
+  assert torch.isfinite(
+    out[0, :, 1:]
+  ).all(), (f"{name}: masked row corrupted neighbouring rows")


### PR DESCRIPTION
Replace warp-level `__any_sync` lazy-rescale votes with thread-level per-row guards where measured non-regressing, and document why the rest keep the vote:

- fp4 family (3 sites): fragment-level guard `scores_scale(mi) < 1.0f` in `SoftmaxFused::rescale_acc` (shared by persist_d/split_d and SoftmaxFusedMxfp8); fp4 persist_d converged to in-place `if (kv_tile > 0) rescale_acc(tOrO_store)`. fp4 attn-mask -3.7% (D64) / -4.7% (D320), all other tasks ~0%.
- native family (2 sites + shared helper): drop the need_rescale tail param from sync_rescaling_tiling_o, clamp factors branchlessly `(f < 1.0f) ? f : 1.0f` (also rejects NaN on all-masked rows); sm_80/sm_120 split_d drop the vote. A/B: sm_80 +-0.3% all tasks, sm_120 within noise (min-of-5).
- fp8 (2) + cute fp16 (4) evaluated and REVERTED to the vote form: a thread-local guard inside the unrolled split-D rescale multiply loop introduces cross-lane divergence + predicated FMAs; attn-mask regressed fp8_D512 +23.9% (33.99->42.1ms), fp8_D768 +6.8%, cute_D128 +2.9%.
- fp4 split_d_m4n2: exempted (vote kept) with an in-code comment; the vote's compiled form is load-bearing for the PC-0-5 stability.

m4n2 bf16 control experiment: HEAD (all csrc changes stashed) also fails the pure-bias determinism probe 10/10 on bf16 inputs with the same d=[192,224) fingerprint -- the mode-0 "pure sequence stable" equilibrium is dtype dependent (validated on fp16). The race gate test is restored to fp16 inputs with a skipif for fp16-trimmed builds (fixes an error on default builds since PC-15).

Tests: new tests/test_ffpa_lazy_rescale_determinism.py (5 shapes, no-bias prelude x3 -> bias self-loop x3 int16 bitwise, plus all-masked-row family assertions); pytest 468 passed / 292 skipped. Bench: 16-config A/B vs HEAD with SDPA-reference consistency check (first baseline round was GPU-polluted; polluted configs re-collected via HEAD control builds).

RFC PC-11 and SKILL.md sections updated to the final per-family form.